### PR TITLE
add conversion of &str to CString in set_language method

### DIFF
--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_int;
+use std::ffi::{c_int, CString};
 use std::marker::PhantomData;
 
 pub enum SamplingStrategy {
@@ -113,7 +113,8 @@ impl<'a> FullParams<'a> {
     ///
     /// Defaults to "en".
     pub fn set_language(&mut self, language: &'a str) {
-        self.fp.language = language.as_ptr() as *const _;
+        let c_lang = CString::new(language).expect("Language contains null byte");
+        self.fp.language = c_lang.into_raw() as *const _;
     }
 
     /// Set the callback for new segments.


### PR DESCRIPTION
When I used set_language method. I got an error due to a lack of terminate char (‘\0’) and I fixed it.

I’m happy to review the PR and merge it!

code
```rust
    let mut ctx = WhisperContext::new("models/ggml-base.bin").expect("Failed to load model.");
    let mut params = FullParams::new(SamplingStrategy::Greedy { n_past: 0 });

    params.set_language("ja");

    let audio_data = read_wav("audio/output.wav");
    let mut audio_data_float = whisper_rs::convert_integer_to_float_audio(&audio_data);
    audio_data_float.push(0.0);
    let audio_data = whisper_rs::convert_stereo_to_mono_audio(&audio_data_float);

    ctx.full(params, &audio_data[..])
        .expect("Failed to run model");
```

error (console output)

```
whisper_model_load: memory size =    22.83 MB 
whisper_model_load: model size  =   140.54 MB
whisper_lang_id: unknown language 'jaFailed to run modelFailed to get segment[ - ]:
'
whisper_full: progress =   5%
whisper_full: progress =  10%
```