### PR TITLE
Fix print_system_info to correctly return a static &str

### DIFF
--- a/src/standalone.rs
+++ b/src/standalone.rs
@@ -1,7 +1,7 @@
 //! Standalone functions that have no associated type.
 
 use crate::WhisperToken;
-use std::ffi::{c_int, CString};
+use std::ffi::{c_int, CStr, CString};
 
 /// Return the id of the specified language, returns -1 if not found
 ///
@@ -47,6 +47,8 @@ pub fn token_transcribe() -> WhisperToken {
 ///
 /// # C++ equivalent
 /// `const char * whisper_print_system_info()`
-pub fn print_system_info() {
-    unsafe { whisper_rs_sys::whisper_print_system_info() };
+pub fn print_system_info() -> &'static str {
+    let c_buf = unsafe { whisper_rs_sys::whisper_print_system_info() };
+    let c_str = unsafe { CStr::from_ptr(c_buf) };
+    c_str.to_str().unwrap()
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -111,6 +111,7 @@ pub fn convert_stereo_to_mono_audio_simd(samples: &[f32]) -> Vec<f32> {
     mono
 }
 
+#[cfg(feature = "simd")]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -363,7 +363,7 @@ impl WhisperContext {
         unsafe { whisper_rs_sys::whisper_token_beg(self.ctx) }
     }
 
-    /// Print performance statistics to stdout.
+    /// Print performance statistics to stderr.
     ///
     /// # C++ equivalent
     /// `void whisper_print_timings(struct whisper_context * ctx)`

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -12,7 +12,8 @@ fn main() {
         let _: u64 = std::fs::copy(
             "src/bindings.rs",
             env::var("OUT_DIR").unwrap() + "/bindings.rs",
-        ).expect("Failed to copy bindings.rs");
+        )
+        .expect("Failed to copy bindings.rs");
     } else {
         let bindings = bindgen::Builder::default()
             .header("wrapper.h")
@@ -34,7 +35,7 @@ fn main() {
                     "src/bindings.rs",
                     env::var("OUT_DIR").unwrap() + "/bindings.rs",
                 )
-                    .expect("Unable to copy bindings.rs");
+                .expect("Unable to copy bindings.rs");
             }
         }
     };


### PR DESCRIPTION
The underlying whisper-cpp library returns a static string for print_system_info. whisper-rs should convert that to a static &str and return it as well, otherwise this function call is useless.