### PR TITLE
Fixes error in example

### DIFF
--- a/examples/basic_use.rs
+++ b/examples/basic_use.rs
@@ -20,7 +20,7 @@ pub fn usage() {
     // and set the language to translate to to english
     params.set_language("en");
     // we also explicitly disable anything that prints to stdout
-    params.set_print_special_tokens(false);
+    params.set_print_special(false);
     params.set_print_progress(false);
     params.set_print_realtime(false);
     params.set_print_timestamps(false);


### PR DESCRIPTION
## What this PR does: 
Fixes error in example

##What did I do?
Ran `cargo run --example basic_use`  and saw that this error was produced.

```rust
error[E0599]: no method named `set_print_special_tokens` found for struct `FullParams` in the current scope

  --> examples/basic_use.rs:23:12
   |
23 |     params.set_print_special_tokens(false);
   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: there is a method with a similar name: `set_print_special`

For more information about this error, try `rustc --explain E0599`.
```

I simply followed the recommendation of the awesome `rustc` compiler :)