### PR TITLE
Fix build on Windows

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -66,7 +66,7 @@ fn main() {
     let code = std::process::Command::new("cmake")
         .arg("..")
         .arg("-DCMAKE_BUILD_TYPE=Release")
-        .arg("-DBUILD_SHARED_LIBS=ON")
+        .arg("-DBUILD_SHARED_LIBS=OFF")
         .arg("-DWHISPER_ALL_WARNINGS=OFF")
         .arg("-DWHISPER_ALL_WARNINGS_3RD_PARTY=OFF")
         .arg("-DWHISPER_BUILD_TESTS=OFF")

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -86,12 +86,26 @@ fn main() {
     if code.code() != Some(0) {
         panic!("Failed to build libwhisper.a");
     }
+
     // move libwhisper.a to where Cargo expects it (OUT_DIR)
-    std::fs::copy(
-        "Release/whisper.lib",
-        format!("{}/whisper.lib", env::var("OUT_DIR").unwrap()),
-    )
-    .expect("Failed to copy libwhisper.a");
+    #[cfg(target_os="windows")]
+    {
+        std::fs::copy(
+            "Release/whisper.lib",
+            format!("{}/whisper.lib", env::var("OUT_DIR").unwrap()),
+        )
+        .expect("Failed to copy libwhisper.a");
+    }
+
+    #[cfg(not(target_os="windows"))]
+    {
+        std::fs::copy(
+            "libwhisper.a",
+            format!("{}/libwhisper.a", env::var("OUT_DIR").unwrap()),
+        )
+        .expect("Failed to copy libwhisper.a");
+    }
+
     // clean the whisper build directory to prevent Cargo from complaining during crate publish
     _ = std::fs::remove_dir_all("build");
 }

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -58,9 +58,29 @@ fn main() {
     }
 
     // build libwhisper.a
-    env::set_current_dir("whisper.cpp").expect("Unable to change directory");
-    let code = std::process::Command::new("make")
-        .arg("libwhisper.a")
+    env::set_current_dir("whisper.cpp").expect("Unable to change directory to whisper.cpp");
+    _ = std::fs::remove_dir_all("build");
+    _ = std::fs::create_dir("build");
+    env::set_current_dir("build").expect("Unable to change directory to whisper.cpp build");
+
+    let code = std::process::Command::new("cmake")
+        .arg("..")
+        .arg("-DCMAKE_BUILD_TYPE=Release")
+        .arg("-DBUILD_SHARED_LIBS=ON")
+        .arg("-DWHISPER_ALL_WARNINGS=OFF")
+        .arg("-DWHISPER_ALL_WARNINGS_3RD_PARTY=OFF")
+        .arg("-DWHISPER_BUILD_TESTS=OFF")
+        .arg("-DWHISPER_BUILD_EXAMPLES=OFF")
+        .status()
+        .expect("Failed to generate build script");
+    if code.code() != Some(0) {
+        panic!("Failed to generate build script");
+    }
+
+    let code = std::process::Command::new("cmake")
+        .arg("--build")
+        .arg(".")
+        .arg("--config Release")
         .status()
         .expect("Failed to build libwhisper.a");
     if code.code() != Some(0) {
@@ -68,15 +88,12 @@ fn main() {
     }
     // move libwhisper.a to where Cargo expects it (OUT_DIR)
     std::fs::copy(
-        "libwhisper.a",
-        format!("{}/libwhisper.a", env::var("OUT_DIR").unwrap()),
+        "Release/whisper.lib",
+        format!("{}/whisper.lib", env::var("OUT_DIR").unwrap()),
     )
     .expect("Failed to copy libwhisper.a");
     // clean the whisper build directory to prevent Cargo from complaining during crate publish
-    std::process::Command::new("make")
-        .arg("clean")
-        .status()
-        .expect("Failed to clean whisper build directory");
+    _ = std::fs::remove_dir_all("build");
 }
 
 // From https://github.com/alexcrichton/cc-rs/blob/fba7feded71ee4f63cfe885673ead6d7b4f2f454/src/lib.rs#L2462

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -88,7 +88,7 @@ fn main() {
     }
 
     // move libwhisper.a to where Cargo expects it (OUT_DIR)
-    #[cfg(target_os="windows")]
+    #[cfg(target_os = "windows")]
     {
         std::fs::copy(
             "Release/whisper.lib",
@@ -97,7 +97,7 @@ fn main() {
         .expect("Failed to copy libwhisper.a");
     }
 
-    #[cfg(not(target_os="windows"))]
+    #[cfg(not(target_os = "windows"))]
     {
         std::fs::copy(
             "libwhisper.a",


### PR DESCRIPTION
This PR moves the build to use `cmake` instead of `make`. The reason is that `whisper.cpp` doesn't support building for Windows using `make` at the moment. Moreover (even if it did), `cmake` solves several issues such as figuring out which specific compiler version to use and so on.

I have tested that this works on Windows, and it definitely does (at least for Windows 11). I can't really test it on any other OS, so I would appreciate some help for that.

Aside from the move to `cmake`, the only other thing I think might be a problem is the `std::fs::copy` call for move whisper to the `OUT_DIR`. The issue is that different OS will have a differently-named output file. `cargo` knows this and deals with it accordingly, but how to do so in the script I'm unsure.