### PR TITLE
Fix panic in stereo to mono audio conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["examples/full_usage"]
 
 [package]
 name = "whisper-rs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Rust bindings for whisper.cpp"
 license = "Unlicense"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ repository = "https://github.com/tazz4843/whisper-rs"
 [dependencies]
 whisper-rs-sys = { path = "sys", version = "0.3" }
 
+[dev-dependencies]
+hound = "3.5.0"
+
 [features]
 simd = []
 

--- a/examples/audio_transcription.rs
+++ b/examples/audio_transcription.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext};
 
 /// Loads a context and model, processes an audio file, and prints the resulting transcript to stdout.
-fn main() {
+fn main() -> Result<(), &'static str> {
     // Load a context and model.
     let mut ctx = WhisperContext::new("example/path/to/model/whisper.cpp/models/ggml-base.en.bin")
         .expect("failed to load model");
@@ -52,7 +52,7 @@ fn main() {
     // These utilities are provided for convenience, but can be replaced with custom conversion logic.
     // SIMD variants of these functions are also available on nightly Rust (see the docs).
     if channels == 2 {
-        audio = whisper_rs::convert_stereo_to_mono_audio(&audio);
+        audio = whisper_rs::convert_stereo_to_mono_audio(&audio)?;
     } else if channels != 1 {
         panic!(">2 channels unsupported");
     }
@@ -85,4 +85,5 @@ fn main() {
         file.write_all(line.as_bytes())
             .expect("failed to write to file");
     }
+    Ok(())
 }

--- a/examples/audio_transcription.rs
+++ b/examples/audio_transcription.rs
@@ -32,6 +32,7 @@ fn main() {
 
     // Open the audio file.
     let mut reader = hound::WavReader::open("audio.wav").expect("failed to open file");
+    #[allow(unused_variables)]
     let hound::WavSpec {
         channels,
         sample_rate,

--- a/examples/audio_transcription.rs
+++ b/examples/audio_transcription.rs
@@ -1,9 +1,10 @@
 // This example is not going to build in this folder.
-// You need to copy this code into your project and add the whisper_rs dependency in your cargo.toml
+// You need to copy this code into your project and add the dependencies whisper_rs and hound in your cargo.toml
 
 use std::fs::File;
 use std::io::Write;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext};
+use hound;
 
 /// Loads a context and model, processes an audio file, and prints the resulting transcript to stdout.
 fn main() {
@@ -14,7 +15,7 @@ fn main() {
     // Create a params object for running the model.
     // Currently, only the Greedy sampling strategy is implemented, with BeamSearch as a WIP.
     // The number of past samples to consider defaults to 0.
-    let mut params = FullParams::new(SamplingStrategy::Greedy { n_past: 0 });
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 0 });
 
     // Edit params as needed.
     // Set the number of threads to use to 1.
@@ -22,7 +23,7 @@ fn main() {
     // Enable translation.
     params.set_translate(true);
     // Set the language to translate to to English.
-    params.set_language("en");
+    params.set_language(Some("en"));
     // Disable anything that prints to stdout.
     params.set_print_special(false);
     params.set_print_progress(false);

--- a/examples/audio_transcription.rs
+++ b/examples/audio_transcription.rs
@@ -1,10 +1,10 @@
 // This example is not going to build in this folder.
 // You need to copy this code into your project and add the dependencies whisper_rs and hound in your cargo.toml
 
+use hound;
 use std::fs::File;
 use std::io::Write;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext};
-use hound;
 
 /// Loads a context and model, processes an audio file, and prints the resulting transcript to stdout.
 fn main() {

--- a/examples/basic_use.rs
+++ b/examples/basic_use.rs
@@ -5,7 +5,7 @@ use whisper_rs::{FullParams, SamplingStrategy, WhisperContext};
 // note that running this example will not do anything, as it is just a
 // demonstration of how to use the library, and actual usage requires
 // more dependencies than the base library.
-pub fn usage() {
+pub fn usage() -> Result<(), &'static str> {
     // load a context and model
     let mut ctx = WhisperContext::new("path/to/model").expect("failed to load model");
 
@@ -38,7 +38,7 @@ pub fn usage() {
     // SIMD variants of these functions are also available, but only on nightly Rust: see the docs
     let audio_data = whisper_rs::convert_stereo_to_mono_audio(
         &whisper_rs::convert_integer_to_float_audio(&audio_data),
-    );
+    )?;
 
     // now we can run the model
     ctx.full(params, &audio_data[..])
@@ -52,6 +52,8 @@ pub fn usage() {
         let end_timestamp = ctx.full_get_segment_t1(i);
         println!("[{} - {}]: {}", start_timestamp, end_timestamp, segment);
     }
+
+    Ok(())
 }
 
 fn main() {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -120,7 +120,7 @@ mod test {
     pub fn assert_stereo_to_mono_simd() {
         // fake some sample data, of 1028 elements
         let mut samples = Vec::with_capacity(1028);
-        for i in 0..1028 {
+        for i in 0..1029 {
             samples.push(i as f32);
         }
         let mono_simd = convert_stereo_to_mono_audio_simd(&samples);

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -54,6 +54,7 @@ pub fn convert_integer_to_float_audio_simd(samples: &[i16]) -> Vec<f32> {
 
 /// Convert 32 bit floating point stereo PCM audio to 32 bit floating point mono PCM audio.
 ///
+/// If there are an odd number of samples, the last sample is dropped.
 /// This variant does not use SIMD instructions.
 ///
 /// # Arguments
@@ -62,15 +63,12 @@ pub fn convert_integer_to_float_audio_simd(samples: &[i16]) -> Vec<f32> {
 /// # Returns
 /// A vector of 32 bit floating point mono PCM audio samples.
 pub fn convert_stereo_to_mono_audio(samples: &[f32]) -> Vec<f32> {
-    let mut mono = Vec::with_capacity(samples.len() / 2);
-    for i in (0..samples.len()).step_by(2) {
-        mono.push((samples[i] + samples[i + 1]) / 2.0);
-    }
-    mono
+    samples.chunks_exact(2).map(|x| (x[0] + x[1]) / 2.0).collect()
 }
 
 /// Convert 32 bit floating point stereo PCM audio to 32 bit floating point mono PCM audio.
 ///
+/// If there are an odd number of samples, the last sample is dropped.
 /// This variant uses SIMD instructions, and as such is only available on
 /// nightly Rust.
 ///
@@ -104,9 +102,7 @@ pub fn convert_stereo_to_mono_audio_simd(samples: &[f32]) -> Vec<f32> {
     // Handle the remainder.
     // do this normally because it's only a few samples and the overhead of
     // converting to SIMD is not worth it.
-    for i in (0..remainder.len()).step_by(2) {
-        mono.push((remainder[i] + remainder[i + 1]) / 2.0);
-    }
+    mono.extend(convert_stereo_to_mono_audio(remainder));
 
     mono
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -54,7 +54,7 @@ pub fn convert_integer_to_float_audio_simd(samples: &[i16]) -> Vec<f32> {
 
 /// Convert 32 bit floating point stereo PCM audio to 32 bit floating point mono PCM audio.
 ///
-/// If there are an odd number of samples, the last sample is dropped.
+/// If there are an odd number of samples, the last half-sample is dropped.
 /// This variant does not use SIMD instructions.
 ///
 /// # Arguments
@@ -68,7 +68,7 @@ pub fn convert_stereo_to_mono_audio(samples: &[f32]) -> Vec<f32> {
 
 /// Convert 32 bit floating point stereo PCM audio to 32 bit floating point mono PCM audio.
 ///
-/// If there are an odd number of samples, the last sample is dropped.
+/// If there are an odd number of samples, the last half-sample is dropped.
 /// This variant uses SIMD instructions, and as such is only available on
 /// nightly Rust.
 ///

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -63,7 +63,10 @@ pub fn convert_integer_to_float_audio_simd(samples: &[i16]) -> Vec<f32> {
 /// # Returns
 /// A vector of 32 bit floating point mono PCM audio samples.
 pub fn convert_stereo_to_mono_audio(samples: &[f32]) -> Vec<f32> {
-    samples.chunks_exact(2).map(|x| (x[0] + x[1]) / 2.0).collect()
+    samples
+        .chunks_exact(2)
+        .map(|x| (x[0] + x[1]) / 2.0)
+        .collect()
 }
 
 /// Convert 32 bit floating point stereo PCM audio to 32 bit floating point mono PCM audio.


### PR DESCRIPTION
If you call convert_stereo_to_mono_audio(samples: &[f32]) with an odd number of samples, it panicked.
This was because the algorithm did a step by 2 and then accessed the value via an index of i+1, which will not exist at the end of a slice with an odd number of samples.

There were two possible solutions for this.
1. Return a result in case in the case that the number of elements is odd. This seems like a good option since it is in fact an error (you shouldn't have a half sample of data), but would require an API change externally.
2. Drop the last half sample. This is simpler.

In this pull request, I implemented the second option for simplicity. In the process, I also simplified the code into one functional line that uses collect, which is usually faster.

Implementing the first version would also be possible, but there should of course be a version change for a public API change.

Let me know if there is anything I should change about this.
Thank you to all the core developers for your time with this amazing project!