### PR TITLE
cmake build args fix

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -80,7 +80,8 @@ fn main() {
     let code = std::process::Command::new("cmake")
         .arg("--build")
         .arg(".")
-        .arg("--config Release")
+        .arg("--config")
+        .arg("Release")
         .status()
         .expect("Failed to build libwhisper.a");
     if code.code() != Some(0) {


### PR DESCRIPTION
I was running into an issue building `whisper-rs` inside a docker image, I believe due to a newer cmake version:

Here's the relevant error msg
```
..
#11 214.0   -- Generating done
#11 214.0   -- Build files have been written to: /usr/local/cargo/git/checkouts/whisper-rs-c8b9fa7c09c8c913/cf27802/sys/whisper.cpp/build
#11 214.0 
#11 214.0   --- stderr
#11 214.0   Unknown argument --config Release
#11 214.0   Usage: cmake --build <dir> [options] [-- [native-options]]
...
```

It ended up being a simple fix, just splitting up those args got it working. Tested working outside of the docker image as well.