### PR TITLE
Support for MSVC environment

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,14 +19,13 @@ ar = "C:\\msys64\\ucrt64\\bin\\ar.exe"
 
 # Running on Windows using Microsoft Visual Studio C++
 
-It has been reported that it is also possible to build whisper-rs using Visual Studio C++. 
+It has been reported that it is also possible to build whisper-rs using Visual Studio C++.
 
-Make sure you have installed and in the path: 
+Make sure you have installed and in the path:
 
 - Visual Studio C++
 - cmake
-
-You may need to clone the git repository instead of using the Cargo package.
+- LLVM(clang)
 
 # Running on M1 OSX
 


### PR DESCRIPTION
- updated whisper-cpp to v1.3.0 because the build in MSVC is ok after update whisper-cpp to v1.3.0
  - whisper-cpp's MSVC build had problem from Japanese character "『" and "』" encoding problem
  - MSVC missleaded the file has SJIS but after v1.3.0, CMakeList.txt configure it is UTF-8 explicitly so now MSVC can build it.
- And I had tested it with MSVC clean environment. Just following is reportable:
  - we need to add three dependencies for this build. We need to add these dependencies for PATH.
    - 1. MSVC itself
    - 2. CMake
    - 3. LLVM(clang)
  - It seems buildable it by `cargo` so we don't need to build it from git repository.
- So I had rewrite `BUILDING.md`