### PR TITLE
impl Error to improve compatibility

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -61,3 +61,59 @@ impl From<NulError> for WhisperError {
         }
     }
 }
+
+impl std::fmt::Display for WhisperError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use WhisperError::*;
+        match self {
+            InitError => write!(f, "Failed to create a new whisper context."),
+            SpectrogramNotInitialized => write!(f, "User didn't initialize spectrogram."),
+            EncodeNotComplete => write!(f, "Encode was not called."),
+            DecodeNotComplete => write!(f, "Decode was not called."),
+            UnableToCalculateSpectrogram => {
+                write!(f, "Failed to calculate the spectrogram for some reason.")
+            }
+            UnableToCalculateEvaluation => write!(f, "Failed to evaluate model."),
+            FailedToEncode => write!(f, "Failed to run the encoder."),
+            FailedToDecode => write!(f, "Failed to run the decoder."),
+            InvalidMelBands => write!(f, "Invalid number of mel bands."),
+            InvalidThreadCount => write!(f, "Invalid thread count."),
+            InvalidUtf8 {
+                valid_up_to,
+                error_len: Some(len),
+            } => write!(
+                f,
+                "Invalid UTF-8 detected in a string from Whisper. Index: {}, Length: {}.",
+                valid_up_to, len
+            ),
+            InvalidUtf8 {
+                valid_up_to,
+                error_len: None,
+            } => write!(
+                f,
+                "Invalid UTF-8 detected in a string from Whisper. Index: {}.",
+                valid_up_to
+            ),
+            NullByteInString { idx } => write!(
+                f,
+                "A null byte was detected in a user-provided string. Index: {}",
+                idx
+            ),
+            NullPointer => write!(f, "Whisper returned a null pointer."),
+            InvalidText => write!(
+                f,
+                "Whisper failed to convert the provided text into tokens."
+            ),
+            FailedToCreateState => write!(f, "Creating a state pointer failed."),
+            StateIdAlreadyExists => write!(f, "State pointer ID already exists."),
+            StateIdDoesNotExist => write!(f, "State pointer ID does not exist."),
+            GenericError(c_int) => write!(
+                f,
+                "Generic whisper error. Varies depending on the function. Error code: {}",
+                c_int
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WhisperError {}


### PR DESCRIPTION
# What?
- `impl std::error::Error for WhisperError` to improve error compatibility.
- Also impl `std::fmt::Display` for the struct because the implementation is required from `std::error::Error`.

# Why ?
- `std::error::Error` is the trait for expressing errors in standard.
- And some of error handling libraries requires Error implemented struct for Result.
  - for examples: `error-stack` have default `std::error::Error` implementation for `Context` struct.