### PR TITLE
Add coreml feature flag and build.rs updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hound = "3.5.0"
 
 [features]
 simd = []
+coreml = ["whisper-rs-sys/coreml"]
 
 [package.metadata.docs.rs]
 features = ["simd"]

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -25,6 +25,9 @@ include = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+coreml = []
+
 [dependencies]
 
 [build-dependencies]

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -135,7 +135,7 @@ fn main() {
             format!("{}/libwhisper.coreml.a", env::var("OUT_DIR").unwrap()),
         )
         .expect("Failed to copy libwhisper.coreml.a");
-    }    
+    }
 
     // clean the whisper build directory to prevent Cargo from complaining during crate publish
     env::set_current_dir("..").expect("Unable to change directory to whisper.cpp");


### PR DESCRIPTION
I've added a feature to whisper-rs and whisper-rs-sys that will build whisper.cpp with Apple CoreML support. This improves execution time by 3x-5x on my MacBook Air M1.

In addition to adding -DWHISPER_COREML=1 to the cmake arguments as documented in the whisper.cpp README, building whisper-rs-sys requires adding the Foundation and CoreML frameworks and linking to an additional generated library, libwhisper.coreml.a.

To generate the CoreML models, you will need to have XCode installed. Converting and loading the larger models (small+) may require a significant amount of time; I have not yet been able to successfully convert the medium or large models on my system. Hopefully a future whisper.cpp version will support enabling and disabling CoreML at run time.