### PR TITLE
fix: public WhisperState from lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use standalone::*;
 pub use utilities::*;
 pub use whisper_ctx::WhisperContext;
 pub use whisper_params::{FullParams, SamplingStrategy};
+pub use whisper_state::WhisperState;
 
 pub type WhisperTokenData = whisper_rs_sys::whisper_token_data;
 pub type WhisperToken = whisper_rs_sys::whisper_token;


### PR DESCRIPTION
It needs to construct `WhisperState` on user code side.
Related: https://github.com/tazz4843/whisper-rs/pull/39