### PR TITLE
Allow fallback to GGML when CoreML model not available.

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -80,6 +80,7 @@ fn main() {
         .arg("-DWHISPER_BUILD_TESTS=OFF")
         .arg("-DWHISPER_BUILD_EXAMPLES=OFF")
         .arg("-DWHISPER_COREML=1")
+        .arg("-DWHISPER_COREML_ALLOW_FALLBACK=1")
         .status()
         .expect("Failed to generate build script");
 


### PR DESCRIPTION
1.4.1 added an additional CMake flag to allow fallback when the CoreML model is not found, but it turns out there is a bug in the implementation: https://github.com/ggerganov/whisper.cpp/pull/893

Posting this here for when that fix is applied and in case anyone else runs into this problem.