### PR TITLE
include ggml-opencl in the crate

### DIFF
--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -15,6 +15,8 @@ include = [
     "whisper.cpp/CMakeLists.txt",
     "whisper.cpp/ggml.c",
     "whisper.cpp/ggml.h",
+    "whisper.cpp/ggml-opencl.c",
+    "whisper.cpp/ggml-opencl.h",
     "whisper.cpp/LICENSE",
     "whisper.cpp/whisper.cpp",
     "whisper.cpp/whisper.h",


### PR DESCRIPTION
The opencl feature can't possibly work without including the actual code.