### PR TITLE
Use position independent code (-fPIC)

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -104,6 +104,8 @@ fn main() {
     #[cfg(feature = "opencl")]
     cmd.arg("-DWHISPER_CLBLAST=ON");
 
+    cmd.arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON");
+
     let code = cmd
         .status()
         .expect("Failed to run `cmake` (is CMake installed?)");


### PR DESCRIPTION
This allows whipser-rs-sys to work when building a cdylib on x86 Linux
in certain conditions.

Without this change, linking can fail with:

```
  = note: /usr/bin/ld: /.../target/debug/deps/libwhisper_rs_sys-d9be91f496c91a32.rlib(whisper.cpp.o): warning: relocation against `_ZTVNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEE@@GLIBCXX_3.4.21' in read-only section `.text.unlikely'
          /usr/bin/ld: /.../target/debug/deps/libwhisper_rs_sys-d9be91f496c91a32.rlib(whisper.cpp.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
          /usr/bin/ld: final link failed: bad value
          collect2: error: ld returned 1 exit status
```

Note that this is one solution. I believe another would be to use the [cmake crate](https://github.com/rust-lang/cmake-rs), which builds with `-fPIC` by default on Linux.
