### PR TITLE
don't remove bindings/javascript/package.json during build

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -163,8 +163,6 @@ fn main() {
     // clean the whisper build directory to prevent Cargo from complaining during crate publish
     env::set_current_dir("..").expect("Unable to change directory to whisper.cpp");
     _ = std::fs::remove_dir_all("build");
-    // for whatever reason this file is generated during build and triggers cargo complaining
-    _ = std::fs::remove_file("bindings/javascript/package.json");
 }
 
 // From https://github.com/alexcrichton/cc-rs/blob/fba7feded71ee4f63cfe885673ead6d7b4f2f454/src/lib.rs#L2462


### PR DESCRIPTION
I've built whisper-rs on both OSX and Linux, and after the build it shows that the file `bindings/javascript/package.json` has been removed the whisper.cpp directory.  It seems like this is intentional, but it causes issues because package.json is a committed file that's part of the whisper.cpp repo.  See:
  https://github.com/ggerganov/whisper.cpp/blob/master/bindings/javascript/package.json

With this change, I do not get any cargo warnings when building on either system, so perhaps whatever was causing the warning earlier has been addressed by a later change.

Feel free to ignore this PR if your experience is different, just wanted to share!
