### PR TITLE
Add instructions for running the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 Rust bindings to [whisper.cpp](https://github.com/ggerganov/whisper.cpp/)
 
 ## Usage
+
+```bash
+git clone --recursive https://github.com/tazz4843/whisper-rs.git
+
+cd whisper-rs
+
+cargo run --example basic_use
+
+cargo run --example audio_transcription
+```
+
 ```rust
 use whisper_rs::{WhisperContext, FullParams, SamplingStrategy};
 


### PR DESCRIPTION
For anyone just looking to validate that they can indeed build and run the examples on their own computer, the README is missing the important note that `git clone` must be given the `--recursive` flag. Without that flag, the result is a baffling error (see below). This PR [adds instructions](https://github.com/artob/whisper-rs/blob/improve-readme/README.md) for cloning and running the examples.

```console
% cargo run --example basic_use
   Compiling memchr v2.5.0
   Compiling libc v0.2.146
   Compiling proc-macro2 v1.0.60
   Compiling glob v0.3.1
   Compiling quote v1.0.28
   Compiling unicode-ident v1.0.9
   Compiling minimal-lexical v0.2.1
   Compiling syn v1.0.109
   Compiling cfg-if v1.0.0
   Compiling bindgen v0.64.0
   Compiling libloading v0.7.4
   Compiling either v1.8.1
   Compiling regex-syntax v0.7.2
   Compiling rustc-hash v1.1.0
   Compiling bitflags v1.3.2
   Compiling log v0.4.19
   Compiling lazycell v1.3.0
   Compiling clang-sys v1.6.1
   Compiling lazy_static v1.4.0
   Compiling shlex v1.1.0
   Compiling peeking_take_while v0.1.2
   Compiling hound v3.5.0
   Compiling regex v1.8.4
   Compiling which v4.4.0
   Compiling nom v7.1.3
   Compiling cexpr v0.6.0
   Compiling whisper-rs-sys v0.6.0 (whisper-rs/sys)
The following warnings were emitted during compilation:

warning: Unable to generate bindings: clang diagnosed error: wrapper.h:1:10: fatal error: 'whisper.h' file not found
warning: Using bundled bindings.rs, which may be out of date

error: failed to run custom build command for `whisper-rs-sys v0.6.0 (whisper-rs/sys)`

Caused by:
  process didn't exit successfully: `whisper-rs/target/debug/build/whisper-rs-sys-2d620388fe53b4e8/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-link-lib=dylib=c++
  cargo:rustc-link-lib=framework=Accelerate
  cargo:rustc-link-search=whisper-rs/target/debug/build/whisper-rs-sys-2976390336e0b243/out
  cargo:rustc-link-lib=static=whisper
  cargo:rerun-if-changed=wrapper.h
  cargo:warning=Unable to generate bindings: clang diagnosed error: wrapper.h:1:10: fatal error: 'whisper.h' file not found

  cargo:warning=Using bundled bindings.rs, which may be out of date

  --- stderr
  wrapper.h:1:10: fatal error: 'whisper.h' file not found
  CMake Warning:
    Ignoring extra path from command line:

     ".."

  CMake Error: The source directory "whisper-rs/sys/whisper.cpp" does not appear to contain CMakeLists.txt.
  Specify --help for usage, or press the help button on the CMake GUI.
  thread 'main' panicked at 'Failed to run `cmake` (is CMake installed?)', sys/build.rs:120:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

PS. @tazz4843 Great to see this project dedicated to the public domain using the Unlicense! (I'm the original [author](https://ar.to/2010/01/set-your-code-free) of the Unlicense.)
