### PR TITLE
calculate mel.n_len as mel spectrogram stride len

### DIFF
--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -123,12 +123,14 @@ impl<'a> WhisperState<'a> {
     /// # C++ equivalent
     /// `int whisper_set_mel(struct whisper_context * ctx, const float * data, int n_len, int n_mel)`
     pub fn set_mel(&mut self, data: &[f32]) -> Result<(), WhisperError> {
+        let hop_size = 160;
+        let n_len = (data.len() / hop_size) * 2;
         let ret = unsafe {
             whisper_rs_sys::whisper_set_mel_with_state(
                 self.ctx,
                 self.ptr,
                 data.as_ptr(),
-                data.len() as c_int,
+                n_len as c_int,
                 80 as c_int,
             )
         };


### PR DESCRIPTION
Based on how whisper.cpp stores the mel spectrogram internally, this is what we need here: mel.n_len is the stride in the time domain. I've successfully passed the JFK test by passing in a spectrogram alone, but this change is required to make it work. 

more info in my implementation:

https://github.com/wavey-ai/mel_spec/blob/3373c64d9e3200485d96c3730b5e6430be074583/src/lib.rs#L141C4-L141C4
https://github.com/wavey-ai/mel_spec/blob/main/src/lib.rs#L475

I'm happy to move some/all of this code into whisper-rs at some point. `set_mel` can't really be used without something like this - it took a while to figure out - but not sure if the stft stuff is a bit out of scope, or not.

