### PR TITLE
Add a rustified progress callback.

### DIFF
--- a/examples/full_usage/src/main.rs
+++ b/examples/full_usage/src/main.rs
@@ -47,7 +47,8 @@ fn main() {
 
     let ctx = WhisperContext::new(&whisper_path.to_string_lossy()).expect("failed to open model");
     let mut state = ctx.create_state().expect("failed to create key");
-    let params = FullParams::new(SamplingStrategy::default());
+    let mut params = FullParams::new(SamplingStrategy::default());
+    params.set_progress_callback_safe(|progress| println!("Progress callback: {}%", progress));
 
     let st = std::time::Instant::now();
     state


### PR DESCRIPTION
This is a proof-of-concept. I will extend the docs once I get maintainer feedback.

# Known issues
- the callback is not called as frequently as the progress print. See the example output:
```
[02:11:22 PM] $ cargo run -- 2830-3980-0043.wav ~/build/whisper.cpp/models/ggml-base.en.bin
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/full_usage 2830-3980-0043.wav /home/marcin/build/whisper.cpp/models/ggml-base.en.bin`
whisper_init_from_file_no_state: loading model from '/home/marcin/build/whisper.cpp/models/ggml-base.en.bin'
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51864
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 512
whisper_model_load: n_audio_head  = 8
whisper_model_load: n_audio_layer = 6
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 512
whisper_model_load: n_text_head   = 8
whisper_model_load: n_text_layer  = 6
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 2
whisper_model_load: mem required  =  310.00 MB (+    6.00 MB per decoder)
whisper_model_load: adding 1607 extra tokens
whisper_model_load: model ctx     =  140.66 MB
whisper_model_load: model size    =  140.54 MB
whisper_init_state: kv self size  =    5.25 MB
whisper_init_state: kv cross size =   17.58 MB
Progress: 0%
whisper_full_with_state: progress =   5%
whisper_full_with_state: progress =  10%
whisper_full_with_state: progress =  15%
whisper_full_with_state: progress =  20%
whisper_full_with_state: progress =  25%
whisper_full_with_state: progress =  30%
whisper_full_with_state: progress =  35%
whisper_full_with_state: progress =  40%
whisper_full_with_state: progress =  45%
whisper_full_with_state: progress =  50%
whisper_full_with_state: progress =  55%
whisper_full_with_state: progress =  60%
whisper_full_with_state: progress =  65%
whisper_full_with_state: progress =  70%
whisper_full_with_state: progress =  75%
whisper_full_with_state: progress =  80%
whisper_full_with_state: progress =  85%
whisper_full_with_state: progress =  90%
whisper_full_with_state: progress =  95%
whisper_full_with_state: progress = 100%
whisper_full_with_state: progress = 105%
whisper_full_with_state: progress = 110%
whisper_full_with_state: progress = 115%
whisper_full_with_state: progress = 120%
whisper_full_with_state: progress = 125%
whisper_full_with_state: progress = 130%
whisper_full_with_state: progress = 135%
whisper_full_with_state: progress = 140%
whisper_full_with_state: progress = 145%
whisper_full_with_state: progress = 150%
whisper_full_with_state: progress = 155%
whisper_full_with_state: progress = 160%
whisper_full_with_state: progress = 165%
whisper_full_with_state: progress = 170%
Progress: 170%
[0 - 340]:  experience proves this.
took 3423ms
```
I have no idea why the progress reaches 170%. Running it on the `jfk.wav` from the whisper.cpp repo prints 100%, as expected.