### PR TITLE
Add access to segment text as bytes

### DIFF
--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -413,6 +413,26 @@ impl<'a> WhisperState<'a> {
         Ok(r_str.to_string())
     }
 
+    /// Get the bytes of the specified segment.
+    ///
+    /// # Arguments
+    /// * segment: Segment index.
+    ///
+    /// # Returns
+    /// Ok(Vec<u8>) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `const char * whisper_full_get_segment_text(struct whisper_context * ctx, int i_segment)`
+    pub fn full_get_segment_bytes(&self, segment: c_int) -> Result<Vec<u8>, WhisperError> {
+        let ret =
+            unsafe { whisper_rs_sys::whisper_full_get_segment_text_from_state(self.ptr, segment) };
+        if ret.is_null() {
+            return Err(WhisperError::NullPointer);
+        }
+        let c_str = unsafe { CStr::from_ptr(ret) };
+        Ok(c_str.to_bytes().to_vec())
+    }
+
     /// Get number of tokens in the specified segment.
     ///
     /// # Arguments


### PR DESCRIPTION
Access method needed for issues related to Issue #46 

### Change
This change adds an additional access method to the whisper_state to allow access to the segment text as a vector of u8.

### Use Case
This is used to handle cases where the segment is not a valid utf-8 string and will throw an error when using full_get_segment_text. This can be pretty common for multi utf-8 byte languages like Mandarin. The segment is not guarantied to end on the proper utf-8 boundary, but can be found in the next segment. When an error is returned from full_get_segment_text the library user can simply grab the bytes (with this new method), buffer them and add the next segment to them until a proper utf8 string is found. 

### Testing 
All testing was done against the following random Chinese language podcast "https://anchor.fm/s/1553388c/podcast/play/60927763/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2022-10-20%2F3b2b6ec4-4399-393e-c056-06e16f5c0c9e.mp3" 
