### PR TITLE
Expose the ggml functions in the bindings.

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -59,6 +59,7 @@ fn main() {
         let bindings = bindgen::Builder::default()
             .header("wrapper.h")
             .clang_arg("-I./whisper.cpp")
+            .clang_arg("-I./ggml.c")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks))
             .generate();
 

--- a/sys/wrapper.h
+++ b/sys/wrapper.h
@@ -1,1 +1,2 @@
 #include <whisper.h>
+#include <ggml.h>


### PR DESCRIPTION
Functions like `ggml_cpu_has_avx` might be useful for downstream consumers.