### PR TITLE
Add a feature flag for Metal acceleration support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ coreml = ["whisper-rs-sys/coreml"]
 cuda = ["whisper-rs-sys/cuda"]
 opencl = ["whisper-rs-sys/opencl"]
 openblas = ["whisper-rs-sys/openblas"]
+metal = ["whisper-rs-sys/metal"]
 test-with-tiny-model = []
 
 [package.metadata.docs.rs]

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -39,6 +39,7 @@ coreml = []
 cuda = []
 opencl = []
 openblas = []
+metal = []
 
 [dependencies]
 

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -130,6 +130,13 @@ fn main() {
     if cfg!(feature = "opencl") {
         config.define("WHISPER_CLBLAST", "ON");
     }
+    
+    if cfg!(feature = "metal") {
+        config.define("WHISPER_METAL", "ON");
+    } else {
+        // Metal is enabled by default, so we need to explicitly disable it
+        config.define("WHISPER_METAL", "OFF");
+    }
 
     let destination = config.build();
 

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -130,7 +130,7 @@ fn main() {
     if cfg!(feature = "opencl") {
         config.define("WHISPER_CLBLAST", "ON");
     }
-    
+
     if cfg!(feature = "metal") {
         config.define("WHISPER_METAL", "ON");
     } else {

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -20,6 +20,12 @@ fn main() {
             println!("cargo:rustc-link-lib=framework=Foundation");
             println!("cargo:rustc-link-lib=framework=CoreML");
         }
+        #[cfg(feature = "metal")]
+        {
+            println!("cargo:rustc-link-lib=framework=Foundation");
+            println!("cargo:rustc-link-lib=framework=Metal");
+            println!("cargo:rustc-link-lib=framework=MetalKit");
+        }
     }
 
     println!("cargo:rustc-link-search={}", env::var("OUT_DIR").unwrap());
@@ -118,6 +124,15 @@ fn main() {
 
     #[cfg(feature = "opencl")]
     cmd.arg("-DWHISPER_CLBLAST=ON");
+    
+    cfg_if! {
+        if #[cfg(feature = "metal")] {
+            cmd.arg("-DWHISPER_METAL=ON");
+        } else {
+            // Metal is enabled by default so we need to explicitly disable it
+            cmd.arg("-DWHISPER_METAL=OFF");
+        }
+    };
 
     cmd.arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON");
 

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -124,7 +124,7 @@ fn main() {
 
     #[cfg(feature = "opencl")]
     cmd.arg("-DWHISPER_CLBLAST=ON");
-    
+
     cfg_if! {
         if #[cfg(feature = "metal")] {
             cmd.arg("-DWHISPER_METAL=ON");


### PR DESCRIPTION
Should hopefully fix errors along the lines of the following on macOS:

```
 Undefined symbols for architecture x86_64:
            "_MTLCopyAllDevices", referenced from:
                _ggml_metal_init in libwhisper_rs_sys-3c0021a7bf9aa3b1.rlib(ggml-metal.m.o)
            "_MTLCreateSystemDefaultDevice", referenced from:
                _ggml_metal_init in libwhisper_rs_sys-3c0021a7bf9aa3b1.rlib(ggml-metal.m.o)
            "_OBJC_CLASS_$_MTLComputePassDescriptor", referenced from:
                objc-class-ref in libwhisper_rs_sys-3c0021a7bf9aa3b1.rlib(ggml-metal.m.o)
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
```
ggml_metal_init: allocating
ggml_metal_init: found device: AMD Radeon Pro 5500M
ggml_metal_init: found device: Intel(R) UHD Graphics 630
ggml_metal_init: picking default device: AMD Radeon Pro 5500M
ggml_metal_init: loading '(null)'
ggml_metal_init: error: Error Domain=NSCocoaErrorDomain Code=258 "The file name is invalid."
```

cc @cenzovit