### PR TITLE
Additional WhisperGrammar and WhisperContextParameters fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use standalone::*;
 pub use utilities::*;
 pub use whisper_ctx::WhisperContext;
 pub use whisper_ctx::WhisperContextParameters;
+pub use whisper_grammar::{WhisperGrammarElement, WhisperGrammarElementType};
 pub use whisper_params::{FullParams, SamplingStrategy};
 pub use whisper_state::WhisperState;
 

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -551,7 +551,7 @@ impl WhisperContextParameters {
     pub fn new() -> Self {
         Self::default()
     }
-    pub fn use_gpu(mut self, use_gpu: bool) -> Self {
+    pub fn use_gpu(&mut self, use_gpu: bool) -> &mut Self {
         self.use_gpu = use_gpu;
         self
     }


### PR DESCRIPTION
I found 2 more issues

- `WhisperGrammar` and `WhisperGrammarElementType` weren't exposed by `lib.rs` so you couldn't make an object to pass to `ctx.set_grammar(Option<&[WhisperGrammarElement]>)`
- You couldn't create a custom `WhisperContextParameters` to pass to `WhisperContext.new_with_x` since you'd get a borrow checker issue as soon as you tried to call `ctx_params.use_gpu(true)` because it was moving the object not borrowing.