### PR TITLE
Fix possible segmentation fault

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -108,6 +108,7 @@ impl std::fmt::Display for WhisperError {
                 "Generic whisper error. Varies depending on the function. Error code: {}",
                 c_int
             ),
+            NoSamples => write!(f, "Input sample buffer was empty."),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,8 @@ pub enum WhisperError {
     InvalidText,
     /// Creating a state pointer failed. Check stderr for more information.
     FailedToCreateState,
+    /// No samples were provided.
+    NoSamples,
 }
 
 impl From<Utf8Error> for WhisperError {

--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -327,6 +327,11 @@ impl<'a> WhisperState<'a> {
     /// # C++ equivalent
     /// `int whisper_full(struct whisper_context * ctx, struct whisper_full_params params, const float * samples, int n_samples)`
     pub fn full(&mut self, params: FullParams, data: &[f32]) -> Result<c_int, WhisperError> {
+        if data.is_empty() {
+            // can randomly trigger segmentation faults if we don't check this
+            return Err(WhisperError::NoSamples);
+        }
+
         let ret = unsafe {
             whisper_rs_sys::whisper_full_with_state(
                 self.ctx,


### PR DESCRIPTION
I've been randomly getting segmentation faults in whisper.cpp. Finally managed to capture and dig into a coredump. Common thread between all of them is they have zero samples. While this is a bug I need to fix myself, this is also a major footgun.