### PR TITLE
fix: LNK2019: unresolved external symbol cuGetErrorString

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -44,6 +44,7 @@ fn main() {
         println!("cargo:rustc-link-lib=cublas");
         println!("cargo:rustc-link-lib=cudart");
         println!("cargo:rustc-link-lib=cublasLt");
+        println!("cargo:rustc-link-lib=cuda");
         cfg_if::cfg_if! {
             if #[cfg(target_os = "windows")] {
                 let cuda_path = PathBuf::from(env::var("CUDA_PATH").unwrap()).join("lib/x64");


### PR DESCRIPTION
add the missing 'cuda' lib, otherwise, link failed on windows with cuda feature enabled