### PR TITLE
fix: Can't find libcuda when build with cuda feature on Linux

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -52,7 +52,9 @@ fn main() {
             } else {
                 println!("cargo:rustc-link-lib=culibos");
                 println!("cargo:rustc-link-search=/usr/local/cuda/lib64");
+                println!("cargo:rustc-link-search=/usr/local/cuda/lib64/stubs");
                 println!("cargo:rustc-link-search=/opt/cuda/lib64");
+                println!("cargo:rustc-link-search=/opt/cuda/lib64/stubs");
             }
         }
     }


### PR DESCRIPTION
On Linux, libcuda is located in the "stubs" sub folder.