### PR TITLE
To improve the usability of WhisperState with Rust's borrow checker

### DIFF
--- a/examples/full_usage/src/main.rs
+++ b/examples/full_usage/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
     }
 
     let original_samples = parse_wav_file(audio_path);
-    let mut samples = Vec::with_capacity(original_samples.len());
+    let mut samples = vec![0.0f32; original_samples.len()]; 
     whisper_rs::convert_integer_to_float_audio(&original_samples, &mut samples)
         .expect("failed to convert samples");
 

--- a/examples/full_usage/src/main.rs
+++ b/examples/full_usage/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
     }
 
     let original_samples = parse_wav_file(audio_path);
-    let mut samples = vec![0.0f32; original_samples.len()]; 
+    let mut samples = vec![0.0f32; original_samples.len()];
     whisper_rs::convert_integer_to_float_audio(&original_samples, &mut samples)
         .expect("failed to convert samples");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use standalone::*;
 use std::sync::Once;
 pub use utilities::*;
 use whisper_ctx::WhisperInnerContext;
-pub use whisper_ctx_wrapper::WhisperContextWrapper;
+pub use whisper_ctx_wrapper::WhisperContext;
 pub use whisper_ctx::WhisperContextParameters;
 pub use whisper_grammar::{WhisperGrammarElement, WhisperGrammarElementType};
 pub use whisper_params::{FullParams, SamplingStrategy};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use standalone::*;
 #[cfg(any(feature = "whisper-cpp-log", feature = "whisper-cpp-tracing"))]
 use std::sync::Once;
 pub use utilities::*;
-pub use whisper_ctx::WhisperContext;
+use whisper_ctx::WhisperInnerContext;
 pub use whisper_ctx_wrapper::WhisperContextWrapper;
 pub use whisper_ctx::WhisperContextParameters;
 pub use whisper_grammar::{WhisperGrammarElement, WhisperGrammarElementType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod whisper_state;
 mod whisper_sys_log;
 #[cfg(feature = "whisper-cpp-tracing")]
 mod whisper_sys_tracing;
+mod whisper_ctx_wrapper;
 
 #[cfg(any(feature = "whisper-cpp-log", feature = "whisper-cpp-tracing"))]
 static LOG_TRAMPOLINE_INSTALL: Once = Once::new();
@@ -22,6 +23,7 @@ pub use standalone::*;
 use std::sync::Once;
 pub use utilities::*;
 pub use whisper_ctx::WhisperContext;
+pub use whisper_ctx_wrapper::WhisperContextWrapper;
 pub use whisper_ctx::WhisperContextParameters;
 pub use whisper_grammar::{WhisperGrammarElement, WhisperGrammarElementType};
 pub use whisper_params::{FullParams, SamplingStrategy};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod standalone;
 mod utilities;
 mod whisper_ctx;
+mod whisper_ctx_wrapper;
 mod whisper_grammar;
 mod whisper_params;
 mod whisper_state;
@@ -12,7 +13,6 @@ mod whisper_state;
 mod whisper_sys_log;
 #[cfg(feature = "whisper-cpp-tracing")]
 mod whisper_sys_tracing;
-mod whisper_ctx_wrapper;
 
 #[cfg(any(feature = "whisper-cpp-log", feature = "whisper-cpp-tracing"))]
 static LOG_TRAMPOLINE_INSTALL: Once = Once::new();
@@ -22,9 +22,9 @@ pub use standalone::*;
 #[cfg(any(feature = "whisper-cpp-log", feature = "whisper-cpp-tracing"))]
 use std::sync::Once;
 pub use utilities::*;
+pub use whisper_ctx::WhisperContextParameters;
 use whisper_ctx::WhisperInnerContext;
 pub use whisper_ctx_wrapper::WhisperContext;
-pub use whisper_ctx::WhisperContextParameters;
 pub use whisper_grammar::{WhisperGrammarElement, WhisperGrammarElementType};
 pub use whisper_params::{FullParams, SamplingStrategy};
 #[cfg(feature = "raw-api")]

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -1,5 +1,4 @@
 use crate::error::WhisperError;
-use crate::whisper_state::WhisperState;
 use crate::WhisperToken;
 use std::ffi::{c_int, CStr, CString};
 
@@ -64,27 +63,6 @@ impl WhisperInnerContext {
                 parameters.to_c_struct(),
             )
         };
-        if ctx.is_null() {
-            Err(WhisperError::InitError)
-        } else {
-            Ok(Self { ctx })
-        }
-    }
-
-    /// Create a new WhisperContext from a file.
-    ///
-    /// # Arguments
-    /// * path: The path to the model file.
-    ///
-    /// # Returns
-    /// Ok(Self) on success, Err(WhisperError) on failure.
-    ///
-    /// # C++ equivalent
-    /// `struct whisper_context * whisper_init_from_file_no_state(const char * path_model)`
-    #[deprecated = "Use `new_with_params` instead"]
-    pub fn new(path: &str) -> Result<Self, WhisperError> {
-        let path_cstr = CString::new(path)?;
-        let ctx = unsafe { whisper_rs_sys::whisper_init_from_file_no_state(path_cstr.as_ptr()) };
         if ctx.is_null() {
             Err(WhisperError::InitError)
         } else {

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -5,15 +5,15 @@ use std::ffi::{c_int, CStr, CString};
 
 /// Safe Rust wrapper around a Whisper context.
 ///
-/// You likely want to create this with [WhisperContext::new_with_params],
-/// create a state with [WhisperContext::create_state],
+/// You likely want to create this with [WhisperInnerContext::new_with_params],
+/// create a state with [WhisperInnerContext::create_state],
 /// then run a full transcription with [WhisperState::full].
 #[derive(Debug)]
-pub struct WhisperContext {
+pub struct WhisperInnerContext {
     pub(crate) ctx: *mut whisper_rs_sys::whisper_context,
 }
 
-impl WhisperContext {
+impl WhisperInnerContext {
     /// Create a new WhisperContext from a file, with parameters.
     ///
     /// # Arguments
@@ -516,7 +516,7 @@ impl WhisperContext {
     }
 }
 
-impl Drop for WhisperContext {
+impl Drop for WhisperInnerContext {
     #[inline]
     fn drop(&mut self) {
         unsafe { whisper_rs_sys::whisper_free(self.ctx) };
@@ -525,8 +525,8 @@ impl Drop for WhisperContext {
 
 // following implementations are safe
 // see https://github.com/ggerganov/whisper.cpp/issues/32#issuecomment-1272790388
-unsafe impl Send for WhisperContext {}
-unsafe impl Sync for WhisperContext {}
+unsafe impl Send for WhisperInnerContext {}
+unsafe impl Sync for WhisperInnerContext {}
 
 pub struct WhisperContextParameters {
     /// Use GPU if available.
@@ -570,7 +570,7 @@ mod test_with_tiny_model {
 
     #[test]
     fn test_tokenize_round_trip() {
-        let ctx = WhisperContext::new(MODEL_PATH).expect("Download the ggml-tiny.en model using 'sys/whisper.cpp/models/download-ggml-model.sh tiny.en'");
+        let ctx = WhisperInnerContext::new(MODEL_PATH).expect("Download the ggml-tiny.en model using 'sys/whisper.cpp/models/download-ggml-model.sh tiny.en'");
         let text_in = " And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.";
         let tokens = ctx.tokenize(text_in, 1024).unwrap();
         let text_out = tokens

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -510,7 +510,7 @@ impl WhisperInnerContext {
     ///
     /// # C++ equivalent
     /// `bool whisper_full_get_segment_speaker_turn_next(struct whisper_context * ctx, int i_segment)`
-    pub fn full_get_segment_speaker_turn_next(&self, i_segment: c_int) -> bool {
+    pub fn full_get_segment_speaker_turn_next(&mut self, i_segment: c_int) -> bool {
         unsafe { whisper_rs_sys::whisper_full_get_segment_speaker_turn_next(self.ctx, i_segment) }
     }
 }

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -114,7 +114,6 @@ impl WhisperInnerContext {
         }
     }
 
-
     /// Convert the provided text into tokens.
     ///
     /// # Arguments

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -511,7 +511,7 @@ impl WhisperContext {
     ///
     /// # C++ equivalent
     /// `bool whisper_full_get_segment_speaker_turn_next(struct whisper_context * ctx, int i_segment)`
-    pub fn full_get_segment_speaker_turn_next(&mut self, i_segment: c_int) -> bool {
+    pub fn full_get_segment_speaker_turn_next(&self, i_segment: c_int) -> bool {
         unsafe { whisper_rs_sys::whisper_full_get_segment_speaker_turn_next(self.ctx, i_segment) }
     }
 }

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -70,7 +70,6 @@ impl WhisperInnerContext {
         }
     }
 
-
     /// Convert the provided text into tokens.
     ///
     /// # Arguments

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -70,27 +70,6 @@ impl WhisperInnerContext {
         }
     }
 
-    /// Create a new WhisperContext from a buffer.
-    ///
-    /// # Arguments
-    /// * buffer: The buffer containing the model.
-    ///
-    /// # Returns
-    /// Ok(Self) on success, Err(WhisperError) on failure.
-    ///
-    /// # C++ equivalent
-    /// `struct whisper_context * whisper_init_from_buffer_no_state(void * buffer, size_t buffer_size)`
-    #[deprecated = "Use `new_from_buffer_with_params` instead"]
-    pub fn new_from_buffer(buffer: &[u8]) -> Result<Self, WhisperError> {
-        let ctx = unsafe {
-            whisper_rs_sys::whisper_init_from_buffer_no_state(buffer.as_ptr() as _, buffer.len())
-        };
-        if ctx.is_null() {
-            Err(WhisperError::InitError)
-        } else {
-            Ok(Self { ctx })
-        }
-    }
 
     /// Convert the provided text into tokens.
     ///

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -10,7 +10,7 @@ use std::ffi::{c_int, CStr, CString};
 /// then run a full transcription with [WhisperState::full].
 #[derive(Debug)]
 pub struct WhisperContext {
-    ctx: *mut whisper_rs_sys::whisper_context,
+    pub(crate) ctx: *mut whisper_rs_sys::whisper_context,
 }
 
 impl WhisperContext {
@@ -114,24 +114,6 @@ impl WhisperContext {
         }
     }
 
-    // we don't implement `whisper_init()` here since i have zero clue what `whisper_model_loader` does
-
-    /// Create a new state object, ready for use.
-    ///
-    /// # Returns
-    /// Ok(WhisperState) on success, Err(WhisperError) on failure.
-    ///
-    /// # C++ equivalent
-    /// `struct whisper_state * whisper_init_state(struct whisper_context * ctx);`
-    pub fn create_state(&self) -> Result<WhisperState, WhisperError> {
-        let state = unsafe { whisper_rs_sys::whisper_init_state(self.ctx) };
-        if state.is_null() {
-            Err(WhisperError::InitError)
-        } else {
-            // SAFETY: this is known to be a valid pointer to a `whisper_state` struct
-            Ok(WhisperState::new(self.ctx, state))
-        }
-    }
 
     /// Convert the provided text into tokens.
     ///

--- a/src/whisper_ctx.rs
+++ b/src/whisper_ctx.rs
@@ -499,20 +499,6 @@ impl WhisperInnerContext {
     pub fn token_transcribe(&self) -> WhisperToken {
         unsafe { whisper_rs_sys::whisper_token_transcribe(self.ctx) }
     }
-
-    /// Get whether the next segment is predicted as a speaker turn
-    ///
-    /// # Arguments
-    /// * i_segment: Segment index.
-    ///
-    /// # Returns
-    /// bool
-    ///
-    /// # C++ equivalent
-    /// `bool whisper_full_get_segment_speaker_turn_next(struct whisper_context * ctx, int i_segment)`
-    pub fn full_get_segment_speaker_turn_next(&mut self, i_segment: c_int) -> bool {
-        unsafe { whisper_rs_sys::whisper_full_get_segment_speaker_turn_next(self.ctx, i_segment) }
-    }
 }
 
 impl Drop for WhisperInnerContext {

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use crate::{WhisperContext, WhisperContextParameters, WhisperError, WhisperState};
+
+pub struct WhisperContextWrapper {
+    ctx: Arc<WhisperContext>,
+}
+
+impl WhisperContextWrapper {
+    /// wrapper of WhisperContext::new_with_params.
+    pub fn new_with_params(
+        path: &str,
+        parameters: WhisperContextParameters,
+    ) -> Result<Self, WhisperError> {
+        let ctx = WhisperContext::new_with_params(path, parameters)?;
+        Ok(Self { ctx: Arc::new(ctx) })
+    }
+
+    // we don't implement `whisper_init()` here since i have zero clue what `whisper_model_loader` does
+
+    /// Create a new state object, ready for use.
+    ///
+    /// # Returns
+    /// Ok(WhisperState) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `struct whisper_state * whisper_init_state(struct whisper_context * ctx);`
+    pub fn create_state(&self) -> Result<WhisperState, WhisperError> {
+        let state = unsafe { whisper_rs_sys::whisper_init_state(self.ctx.ctx) };
+        if state.is_null() {
+            Err(WhisperError::InitError)
+        } else {
+            // SAFETY: this is known to be a valid pointer to a `whisper_state` struct
+            Ok(WhisperState::new(self.ctx.clone(), state))
+        }
+    }
+}

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -448,7 +448,7 @@ impl WhisperContext {
     ///
     /// # C++ equivalent
     /// `bool whisper_full_get_segment_speaker_turn_next(struct whisper_context * ctx, int i_segment)`
-    pub fn full_get_segment_speaker_turn_next(&self, i_segment: c_int) -> bool {
+    pub fn full_get_segment_speaker_turn_next(&mut self, i_segment: c_int) -> bool {
         self.ctx.full_get_segment_speaker_turn_next(i_segment)
     }
 

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -51,22 +51,6 @@ impl WhisperContext {
         Ok(Self::wrap(ctx))
     }
 
-    /// Create a new WhisperContext from a file.
-    ///
-    /// # Arguments
-    /// * path: The path to the model file.
-    ///
-    /// # Returns
-    /// Ok(Self) on success, Err(WhisperError) on failure.
-    ///
-    /// # C++ equivalent
-    /// `struct whisper_context * whisper_init_from_file_no_state(const char * path_model)`
-    #[deprecated = "Use `new_with_params` instead"]
-    pub fn new(path: &str) -> Result<Self, WhisperError> {
-        let ctx = WhisperInnerContext::new(path)?;
-        Ok(Self::wrap(ctx))
-    }
-
     /// Create a new WhisperContext from a buffer.
     ///
     /// # Arguments

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use crate::{WhisperInnerContext, WhisperContextParameters, WhisperError, WhisperState, WhisperToken};
 
-pub struct WhisperContextWrapper {
+pub struct WhisperContext {
     ctx: Arc<WhisperInnerContext>,
 }
 
-impl WhisperContextWrapper {
+impl WhisperContext {
     fn wrap(ctx: WhisperInnerContext) -> Self {
         Self {
             ctx: Arc::new(ctx),

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -51,7 +51,6 @@ impl WhisperContext {
         Ok(Self::wrap(ctx))
     }
 
-
     /// Convert the provided text into tokens.
     ///
     /// # Arguments

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -438,20 +438,6 @@ impl WhisperContext {
         self.ctx.token_transcribe()
     }
 
-    /// Get whether the next segment is predicted as a speaker turn
-    ///
-    /// # Arguments
-    /// * i_segment: Segment index.
-    ///
-    /// # Returns
-    /// bool
-    ///
-    /// # C++ equivalent
-    /// `bool whisper_full_get_segment_speaker_turn_next(struct whisper_context * ctx, int i_segment)`
-    pub fn full_get_segment_speaker_turn_next(&mut self, i_segment: c_int) -> bool {
-        self.ctx.full_get_segment_speaker_turn_next(i_segment)
-    }
-
     // we don't implement `whisper_init()` here since i have zero clue what `whisper_model_loader` does
 
     /// Create a new state object, ready for use.

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -51,21 +51,6 @@ impl WhisperContext {
         Ok(Self::wrap(ctx))
     }
 
-    /// Create a new WhisperContext from a buffer.
-    ///
-    /// # Arguments
-    /// * buffer: The buffer containing the model.
-    ///
-    /// # Returns
-    /// Ok(Self) on success, Err(WhisperError) on failure.
-    ///
-    /// # C++ equivalent
-    /// `struct whisper_context * whisper_init_from_buffer_no_state(void * buffer, size_t buffer_size)`
-    #[deprecated = "Use `new_from_buffer_with_params` instead"]
-    pub fn new_from_buffer(buffer: &[u8]) -> Result<Self, WhisperError> {
-        let ctx = WhisperInnerContext::new_from_buffer(buffer)?;
-        Ok(Self::wrap(ctx))
-    }
 
     /// Convert the provided text into tokens.
     ///

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -1,7 +1,9 @@
 use std::ffi::{c_int, CStr};
 use std::sync::Arc;
 
-use crate::{WhisperInnerContext, WhisperContextParameters, WhisperError, WhisperState, WhisperToken};
+use crate::{
+    WhisperContextParameters, WhisperError, WhisperInnerContext, WhisperState, WhisperToken,
+};
 
 pub struct WhisperContext {
     ctx: Arc<WhisperInnerContext>,
@@ -9,9 +11,7 @@ pub struct WhisperContext {
 
 impl WhisperContext {
     fn wrap(ctx: WhisperInnerContext) -> Self {
-        Self {
-            ctx: Arc::new(ctx),
-        }
+        Self { ctx: Arc::new(ctx) }
     }
 
     /// Create a new WhisperContext from a file, with parameters.
@@ -82,7 +82,6 @@ impl WhisperContext {
         let ctx = WhisperInnerContext::new_from_buffer(buffer)?;
         Ok(Self::wrap(ctx))
     }
-
 
     /// Convert the provided text into tokens.
     ///
@@ -452,7 +451,6 @@ impl WhisperContext {
     pub fn full_get_segment_speaker_turn_next(&self, i_segment: c_int) -> bool {
         self.ctx.full_get_segment_speaker_turn_next(i_segment)
     }
-
 
     // we don't implement `whisper_init()` here since i have zero clue what `whisper_model_loader` does
 

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -1,20 +1,458 @@
+use std::ffi::{c_int, CStr};
 use std::sync::Arc;
 
-use crate::{WhisperContext, WhisperContextParameters, WhisperError, WhisperState};
+use crate::{WhisperContext, WhisperContextParameters, WhisperError, WhisperState, WhisperToken};
 
 pub struct WhisperContextWrapper {
     ctx: Arc<WhisperContext>,
 }
 
 impl WhisperContextWrapper {
-    /// wrapper of WhisperContext::new_with_params.
+    fn wrap(ctx: WhisperContext) -> Self {
+        Self {
+            ctx: Arc::new(ctx),
+        }
+    }
+
+    /// Create a new WhisperContext from a file, with parameters.
+    ///
+    /// # Arguments
+    /// * path: The path to the model file.
+    /// * parameters: A parameter struct containing the parameters to use.
+    ///
+    /// # Returns
+    /// Ok(Self) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `struct whisper_context * whisper_init_from_file_with_params_no_state(const char * path_model, struct whisper_context_params params);`
     pub fn new_with_params(
         path: &str,
         parameters: WhisperContextParameters,
     ) -> Result<Self, WhisperError> {
         let ctx = WhisperContext::new_with_params(path, parameters)?;
-        Ok(Self { ctx: Arc::new(ctx) })
+        Ok(Self::wrap(ctx))
     }
+
+    /// Create a new WhisperContext from a buffer.
+    ///
+    /// # Arguments
+    /// * buffer: The buffer containing the model.
+    ///
+    /// # Returns
+    /// Ok(Self) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `struct whisper_context * whisper_init_from_buffer_with_params_no_state(void * buffer, size_t buffer_size, struct whisper_context_params params);`
+    pub fn new_from_buffer_with_params(
+        buffer: &[u8],
+        parameters: WhisperContextParameters,
+    ) -> Result<Self, WhisperError> {
+        let ctx = WhisperContext::new_from_buffer_with_params(buffer, parameters)?;
+        Ok(Self::wrap(ctx))
+    }
+
+    /// Create a new WhisperContext from a file.
+    ///
+    /// # Arguments
+    /// * path: The path to the model file.
+    ///
+    /// # Returns
+    /// Ok(Self) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `struct whisper_context * whisper_init_from_file_no_state(const char * path_model)`
+    #[deprecated = "Use `new_with_params` instead"]
+    pub fn new(path: &str) -> Result<Self, WhisperError> {
+        let ctx = WhisperContext::new(path)?;
+        Ok(Self::wrap(ctx))
+    }
+
+    /// Create a new WhisperContext from a buffer.
+    ///
+    /// # Arguments
+    /// * buffer: The buffer containing the model.
+    ///
+    /// # Returns
+    /// Ok(Self) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `struct whisper_context * whisper_init_from_buffer_no_state(void * buffer, size_t buffer_size)`
+    #[deprecated = "Use `new_from_buffer_with_params` instead"]
+    pub fn new_from_buffer(buffer: &[u8]) -> Result<Self, WhisperError> {
+        let ctx = WhisperContext::new_from_buffer(buffer)?;
+        Ok(Self::wrap(ctx))
+    }
+
+
+    /// Convert the provided text into tokens.
+    ///
+    /// # Arguments
+    /// * text: The text to convert.
+    ///
+    /// # Returns
+    /// `Ok(Vec<WhisperToken>)` on success, `Err(WhisperError)` on failure.
+    ///
+    /// # C++ equivalent
+    /// `int whisper_tokenize(struct whisper_context * ctx, const char * text, whisper_token * tokens, int n_max_tokens);`
+    pub fn tokenize(
+        &self,
+        text: &str,
+        max_tokens: usize,
+    ) -> Result<Vec<WhisperToken>, WhisperError> {
+        self.ctx.tokenize(text, max_tokens)
+    }
+
+    /// Get n_vocab.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_n_vocab        (struct whisper_context * ctx)`
+    #[inline]
+    pub fn n_vocab(&self) -> c_int {
+        self.ctx.n_vocab()
+    }
+
+    /// Get n_text_ctx.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_n_text_ctx     (struct whisper_context * ctx);`
+    #[inline]
+    pub fn n_text_ctx(&self) -> c_int {
+        self.ctx.n_text_ctx()
+    }
+
+    /// Get n_audio_ctx.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_n_audio_ctx     (struct whisper_context * ctx);`
+    #[inline]
+    pub fn n_audio_ctx(&self) -> c_int {
+        self.ctx.n_audio_ctx()
+    }
+
+    /// Does this model support multiple languages?
+    ///
+    /// # C++ equivalent
+    /// `int whisper_is_multilingual(struct whisper_context * ctx)`
+    #[inline]
+    pub fn is_multilingual(&self) -> bool {
+        self.ctx.is_multilingual()
+    }
+
+    /// Get model_n_vocab.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_vocab      (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_vocab(&self) -> c_int {
+        self.ctx.model_n_vocab()
+    }
+
+    /// Get model_n_audio_ctx.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_audio_ctx    (struct whisper_context * ctx)`
+    #[inline]
+    pub fn model_n_audio_ctx(&self) -> c_int {
+        self.ctx.model_n_audio_ctx()
+    }
+
+    /// Get model_n_audio_state.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_audio_state(struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_audio_state(&self) -> c_int {
+        self.ctx.model_n_audio_state()
+    }
+
+    /// Get model_n_audio_head.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_audio_head (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_audio_head(&self) -> c_int {
+        self.ctx.model_n_audio_head()
+    }
+
+    /// Get model_n_audio_layer.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_audio_layer(struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_audio_layer(&self) -> c_int {
+        self.ctx.model_n_audio_layer()
+    }
+
+    /// Get model_n_text_ctx.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_text_ctx     (struct whisper_context * ctx)`
+    #[inline]
+    pub fn model_n_text_ctx(&self) -> c_int {
+        self.ctx.model_n_text_ctx()
+    }
+
+    /// Get model_n_text_state.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_text_state (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_text_state(&self) -> c_int {
+        self.ctx.model_n_text_state()
+    }
+
+    /// Get model_n_text_head.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_text_head  (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_text_head(&self) -> c_int {
+        self.ctx.model_n_text_head()
+    }
+
+    /// Get model_n_text_layer.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_text_layer (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_text_layer(&self) -> c_int {
+        self.ctx.model_n_text_layer()
+    }
+
+    /// Get model_n_mels.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_n_mels       (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_n_mels(&self) -> c_int {
+        self.ctx.model_n_mels()
+    }
+
+    /// Get model_ftype.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_ftype          (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_ftype(&self) -> c_int {
+        self.ctx.model_ftype()
+    }
+
+    /// Get model_type.
+    ///
+    /// # Returns
+    /// c_int
+    ///
+    /// # C++ equivalent
+    /// `int whisper_model_type         (struct whisper_context * ctx);`
+    #[inline]
+    pub fn model_type(&self) -> c_int {
+        self.ctx.model_type()
+    }
+
+    // token functions
+    /// Convert a token ID to a string.
+    ///
+    /// # Arguments
+    /// * token_id: ID of the token.
+    ///
+    /// # Returns
+    /// Ok(&str) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `const char * whisper_token_to_str(struct whisper_context * ctx, whisper_token token)`
+    pub fn token_to_str(&self, token_id: WhisperToken) -> Result<&str, WhisperError> {
+        self.ctx.token_to_str(token_id)
+    }
+
+    /// Convert a token ID to a &CStr.
+    ///
+    /// # Arguments
+    /// * token_id: ID of the token.
+    ///
+    /// # Returns
+    /// Ok(String) on success, Err(WhisperError) on failure.
+    ///
+    /// # C++ equivalent
+    /// `const char * whisper_token_to_str(struct whisper_context * ctx, whisper_token token)`
+    pub fn token_to_cstr(&self, token_id: WhisperToken) -> Result<&CStr, WhisperError> {
+        self.ctx.token_to_cstr(token_id)
+    }
+
+    /// Undocumented but exposed function in the C++ API.
+    /// `const char * whisper_model_type_readable(struct whisper_context * ctx);`
+    ///
+    /// # Returns
+    /// Ok(String) on success, Err(WhisperError) on failure.
+    pub fn model_type_readable(&self) -> Result<String, WhisperError> {
+        self.ctx.model_type_readable()
+    }
+
+    /// Get the ID of the eot token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_eot (struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_eot(&self) -> WhisperToken {
+        self.ctx.token_eot()
+    }
+
+    /// Get the ID of the sot token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_sot (struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_sot(&self) -> WhisperToken {
+        self.ctx.token_sot()
+    }
+
+    /// Get the ID of the solm token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_solm(struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_solm(&self) -> WhisperToken {
+        self.ctx.token_solm()
+    }
+
+    /// Get the ID of the prev token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_prev(struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_prev(&self) -> WhisperToken {
+        self.ctx.token_prev()
+    }
+
+    /// Get the ID of the nosp token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_nosp(struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_nosp(&self) -> WhisperToken {
+        self.ctx.token_nosp()
+    }
+
+    /// Get the ID of the not token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_not (struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_not(&self) -> WhisperToken {
+        self.ctx.token_not()
+    }
+
+    /// Get the ID of the beg token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_beg (struct whisper_context * ctx)`
+    #[inline]
+    pub fn token_beg(&self) -> WhisperToken {
+        self.ctx.token_beg()
+    }
+
+    /// Get the ID of a specified language token
+    ///
+    /// # Arguments
+    /// * lang_id: ID of the language
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_lang(struct whisper_context * ctx, int lang_id)`
+    #[inline]
+    pub fn token_lang(&self, lang_id: c_int) -> WhisperToken {
+        self.ctx.token_lang(lang_id)
+    }
+
+    /// Print performance statistics to stderr.
+    ///
+    /// # C++ equivalent
+    /// `void whisper_print_timings(struct whisper_context * ctx)`
+    #[inline]
+    pub fn print_timings(&self) {
+        self.ctx.print_timings()
+    }
+
+    /// Reset performance statistics.
+    ///
+    /// # C++ equivalent
+    /// `void whisper_reset_timings(struct whisper_context * ctx)`
+    #[inline]
+    pub fn reset_timings(&self) {
+        self.ctx.reset_timings()
+    }
+
+    // task tokens
+    /// Get the ID of the translate task token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_translate ()`
+    pub fn token_translate(&self) -> WhisperToken {
+        self.ctx.token_translate()
+    }
+
+    /// Get the ID of the transcribe task token.
+    ///
+    /// # C++ equivalent
+    /// `whisper_token whisper_token_transcribe()`
+    pub fn token_transcribe(&self) -> WhisperToken {
+        self.ctx.token_transcribe()
+    }
+
+    /// Get whether the next segment is predicted as a speaker turn
+    ///
+    /// # Arguments
+    /// * i_segment: Segment index.
+    ///
+    /// # Returns
+    /// bool
+    ///
+    /// # C++ equivalent
+    /// `bool whisper_full_get_segment_speaker_turn_next(struct whisper_context * ctx, int i_segment)`
+    pub fn full_get_segment_speaker_turn_next(&self, i_segment: c_int) -> bool {
+        self.ctx.full_get_segment_speaker_turn_next(i_segment)
+    }
+
 
     // we don't implement `whisper_init()` here since i have zero clue what `whisper_model_loader` does
 

--- a/src/whisper_ctx_wrapper.rs
+++ b/src/whisper_ctx_wrapper.rs
@@ -1,14 +1,14 @@
 use std::ffi::{c_int, CStr};
 use std::sync::Arc;
 
-use crate::{WhisperContext, WhisperContextParameters, WhisperError, WhisperState, WhisperToken};
+use crate::{WhisperInnerContext, WhisperContextParameters, WhisperError, WhisperState, WhisperToken};
 
 pub struct WhisperContextWrapper {
-    ctx: Arc<WhisperContext>,
+    ctx: Arc<WhisperInnerContext>,
 }
 
 impl WhisperContextWrapper {
-    fn wrap(ctx: WhisperContext) -> Self {
+    fn wrap(ctx: WhisperInnerContext) -> Self {
         Self {
             ctx: Arc::new(ctx),
         }
@@ -29,7 +29,7 @@ impl WhisperContextWrapper {
         path: &str,
         parameters: WhisperContextParameters,
     ) -> Result<Self, WhisperError> {
-        let ctx = WhisperContext::new_with_params(path, parameters)?;
+        let ctx = WhisperInnerContext::new_with_params(path, parameters)?;
         Ok(Self::wrap(ctx))
     }
 
@@ -47,7 +47,7 @@ impl WhisperContextWrapper {
         buffer: &[u8],
         parameters: WhisperContextParameters,
     ) -> Result<Self, WhisperError> {
-        let ctx = WhisperContext::new_from_buffer_with_params(buffer, parameters)?;
+        let ctx = WhisperInnerContext::new_from_buffer_with_params(buffer, parameters)?;
         Ok(Self::wrap(ctx))
     }
 
@@ -63,7 +63,7 @@ impl WhisperContextWrapper {
     /// `struct whisper_context * whisper_init_from_file_no_state(const char * path_model)`
     #[deprecated = "Use `new_with_params` instead"]
     pub fn new(path: &str) -> Result<Self, WhisperError> {
-        let ctx = WhisperContext::new(path)?;
+        let ctx = WhisperInnerContext::new(path)?;
         Ok(Self::wrap(ctx))
     }
 
@@ -79,7 +79,7 @@ impl WhisperContextWrapper {
     /// `struct whisper_context * whisper_init_from_buffer_no_state(void * buffer, size_t buffer_size)`
     #[deprecated = "Use `new_from_buffer_with_params` instead"]
     pub fn new_from_buffer(buffer: &[u8]) -> Result<Self, WhisperError> {
-        let ctx = WhisperContext::new_from_buffer(buffer)?;
+        let ctx = WhisperInnerContext::new_from_buffer(buffer)?;
         Ok(Self::wrap(ctx))
     }
 

--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_int, CStr};
 use std::sync::Arc;
 
-use crate::{FullParams, WhisperInnerContext, WhisperError, WhisperToken, WhisperTokenData};
+use crate::{FullParams, WhisperError, WhisperInnerContext, WhisperToken, WhisperTokenData};
 
 /// Rustified pointer to a Whisper state.
 #[derive(Debug)]
@@ -27,10 +27,7 @@ impl WhisperState {
         ctx: Arc<WhisperInnerContext>,
         ptr: *mut whisper_rs_sys::whisper_state,
     ) -> Self {
-        Self {
-            ctx,
-            ptr,
-        }
+        Self { ctx, ptr }
     }
 
     /// Convert raw PCM audio (floating point 32 bit) to log mel spectrogram.
@@ -495,7 +492,10 @@ impl WhisperState {
     ) -> Result<String, WhisperError> {
         let ret = unsafe {
             whisper_rs_sys::whisper_full_get_token_text_from_state(
-                self.ctx.ctx, self.ptr, segment, token,
+                self.ctx.ctx,
+                self.ptr,
+                segment,
+                token,
             )
         };
         if ret.is_null() {
@@ -527,7 +527,10 @@ impl WhisperState {
     ) -> Result<String, WhisperError> {
         let ret = unsafe {
             whisper_rs_sys::whisper_full_get_token_text_from_state(
-                self.ctx.ctx, self.ptr, segment, token,
+                self.ctx.ctx,
+                self.ptr,
+                segment,
+                token,
             )
         };
         if ret.is_null() {

--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -42,7 +42,7 @@ impl WhisperState {
     ///
     /// # C++ equivalent
     /// `int whisper_pcm_to_mel(struct whisper_context * ctx, const float * samples, int n_samples, int n_threads)`
-    pub fn pcm_to_mel(&self, pcm: &[f32], threads: usize) -> Result<(), WhisperError> {
+    pub fn pcm_to_mel(&mut self, pcm: &[f32], threads: usize) -> Result<(), WhisperError> {
         if threads < 1 {
             return Err(WhisperError::InvalidThreadCount);
         }
@@ -78,7 +78,7 @@ impl WhisperState {
     /// # C++ equivalent
     /// `int whisper_pcm_to_mel(struct whisper_context * ctx, const float * samples, int n_samples, int n_threads)`
     pub fn pcm_to_mel_phase_vocoder(
-        &self,
+        &mut self,
         pcm: &[f32],
         threads: usize,
     ) -> Result<(), WhisperError> {
@@ -119,7 +119,7 @@ impl WhisperState {
     ///
     /// # C++ equivalent
     /// `int whisper_set_mel(struct whisper_context * ctx, const float * data, int n_len, int n_mel)`
-    pub fn set_mel(&self, data: &[f32]) -> Result<(), WhisperError> {
+    pub fn set_mel(&mut self, data: &[f32]) -> Result<(), WhisperError> {
         let hop_size = 160;
         let n_len = (data.len() / hop_size) * 2;
         let ret = unsafe {
@@ -152,7 +152,7 @@ impl WhisperState {
     ///
     /// # C++ equivalent
     /// `int whisper_encode(struct whisper_context * ctx, int offset, int n_threads)`
-    pub fn encode(&self, offset: usize, threads: usize) -> Result<(), WhisperError> {
+    pub fn encode(&mut self, offset: usize, threads: usize) -> Result<(), WhisperError> {
         if threads < 1 {
             return Err(WhisperError::InvalidThreadCount);
         }
@@ -189,7 +189,7 @@ impl WhisperState {
     /// # C++ equivalent
     /// `int whisper_decode(struct whisper_context * ctx, const whisper_token * tokens, int n_tokens, int n_past, int n_threads)`
     pub fn decode(
-        &self,
+        &mut self,
         tokens: &[WhisperToken],
         n_past: usize,
         threads: usize,
@@ -324,7 +324,7 @@ impl WhisperState {
     ///
     /// # C++ equivalent
     /// `int whisper_full(struct whisper_context * ctx, struct whisper_full_params params, const float * samples, int n_samples)`
-    pub fn full(&self, params: FullParams, data: &[f32]) -> Result<c_int, WhisperError> {
+    pub fn full(&mut self, params: FullParams, data: &[f32]) -> Result<c_int, WhisperError> {
         if data.is_empty() {
             // can randomly trigger segmentation faults if we don't check this
             return Err(WhisperError::NoSamples);
@@ -613,7 +613,7 @@ impl WhisperState {
     ///
     /// # C++ equivalent
     /// `bool whisper_full_get_segment_speaker_turn_next_from_state(struct whisper_state * state, int i_segment)`
-    pub fn full_get_segment_speaker_turn_next(&self, i_segment: c_int) -> bool {
+    pub fn full_get_segment_speaker_turn_next(&mut self, i_segment: c_int) -> bool {
         unsafe {
             whisper_rs_sys::whisper_full_get_segment_speaker_turn_next_from_state(
                 self.ptr, i_segment,

--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -1,12 +1,12 @@
 use std::ffi::{c_int, CStr};
 use std::sync::Arc;
 
-use crate::{FullParams, WhisperContext, WhisperError, WhisperToken, WhisperTokenData};
+use crate::{FullParams, WhisperInnerContext, WhisperError, WhisperToken, WhisperTokenData};
 
 /// Rustified pointer to a Whisper state.
 #[derive(Debug)]
 pub struct WhisperState {
-    ctx: Arc<WhisperContext>,
+    ctx: Arc<WhisperInnerContext>,
     ptr: *mut whisper_rs_sys::whisper_state,
 }
 
@@ -24,7 +24,7 @@ impl Drop for WhisperState {
 
 impl WhisperState {
     pub(crate) fn new(
-        ctx: Arc<WhisperContext>,
+        ctx: Arc<WhisperInnerContext>,
         ptr: *mut whisper_rs_sys::whisper_state,
     ) -> Self {
         Self {


### PR DESCRIPTION
I encountered difficulties using the state correctly in callbacks due to challenges with the borrow checker. I adopted the approach suggested by @jcsoo in this discussion: https://github.com/tazz4843/whisper-rs/issues/86#issuecomment-2058049340.

Here's a summary of the refactoring changes:
1. Retain the original WhisperContext as the internal context, used privately within both the WhisperContext wrapper and WhisperState.
2. Designate the wrapper as WhisperContext and proxy all methods to the inner context, ensuring the public API remains unchanged.

I'd appreciate your feedback on this approach :)