### PR TITLE
Fix set_grammar to set pointer to array of pointers

### DIFF
--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -615,7 +615,6 @@ impl<'a, 'b> FullParams<'a, 'b> {
                 ptrs.push(rule.as_ptr());
             }
 
-            
             // turn into ptr and len
             let grammar_ptr = ptrs.as_ptr() as *mut _;
             let grammar_len = ptrs.len();

--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -594,7 +594,7 @@ impl<'a, 'b> FullParams<'a, 'b> {
     }
 
     /// Set the grammar block to be passed to the whisper model. This is a boxed slice of u64s, with
-    /// the first element being the number of grammar rules, followed by a table of contents containing 
+    /// the first element being the number of grammar rules, followed by a table of contents containing
     /// the starting index of each rule relative to the start of the block. The table of contents
     /// will be rewritten to contain pointers to the grammar rules.
     ///

--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -593,7 +593,7 @@ impl<'a, 'b> FullParams<'a, 'b> {
         self.fp.abort_callback_user_data = user_data;
     }
 
-    /// Set the grammar block to be passed to the whisper model. This is a boxed slice of u64s, with
+    /// Set the grammar block to be passed to the whisper model. This is a slice of u64s, with
     /// the first element being the number of grammar rules, followed by a table of contents containing
     /// the starting index of each rule relative to the start of the block. The table of contents
     /// will be rewritten to contain pointers to the grammar rules.
@@ -602,8 +602,10 @@ impl<'a, 'b> FullParams<'a, 'b> {
     /// The caller must ensure that the grammar block is valid and that the grammar rules are valid.
     /// Invalid grammar rules can cause undefined behavior.
     ///
-    pub fn set_grammar_block(&mut self, grammar_block: Option<Box<[u64]>>) {
-        if let Some(mut grammar_block) = grammar_block {
+    pub fn set_grammar_block(&mut self, grammar_block: Option<&[u64]>) {
+        if let Some(grammar_block) = grammar_block {
+            let mut grammar_block = grammar_block.to_vec().into_boxed_slice();
+
             // The first element is the number of grammar rules
             let n_grammar_rules = grammar_block[0] as usize;
 


### PR DESCRIPTION
The signature for set_grammar is incorrect - it currently takes `Option<Vec<WhisperGrammarElement>>`, but `whisper_full_params` requires
```
const whisper_grammar_element ** grammar_rules;
```

i.e. a pointer to an array of grammar rules.

I updated the signature to take `Option<Vec<Vec<WhisperGrammarElement>>>`, which is then transformed into `Vec<Box<[whisper_grammar_element]>>`. I then added a member to store the pointers to the individual grammar element slices, and store the pointer to that member in grammar_rules.

I think this should be OK if the self.grammar and self.grammar_pointers are never modified without modifying grammar_rules and n_grammar_rules at the same time. The underlying storage should be freed when FullParams is dropped.

I don't know that this is the best function signature since it requires cloning the grammar, so I'm open to suggestions.

I tested this out and it does appear to work, though I don't know how to figure out if a rule has been fully matched.