### PR TITLE
feat(sys): pass whisper cmake flags from environment variables

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -147,6 +147,13 @@ fn main() {
         config.define("CMAKE_BUILD_TYPE", "RelWithDebInfo");
     }
 
+    // Allow passing any WHISPER cmake flag
+    for (key, value) in env::vars() {
+        if key.starts_with("WHISPER_") && key != "WHISPER_DONT_GENERATE_BINDINGS" {
+            config.define(&key, &value);
+        }
+    }
+
     let destination = config.build();
 
     if target.contains("window") && !target.contains("gnu") {


### PR DESCRIPTION
Allow passing cmake flags to whisper from environment variables when compiling `whisper-rs`
Example flags: [CMakeLists.txt#L66C0-L72C0](https://github.com/ggerganov/whisper.cpp/blob/c7b6988678779901d02ceba1a8212d2c9908956e/CMakeLists.txt#L66C0-L72C0)