### PR TITLE
fix: lang_detect not working properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["examples/full_usage"]
 
 [package]
 name = "whisper-rs"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Rust bindings for whisper.cpp"
 license = "Unlicense"
@@ -14,7 +14,7 @@ repository = "https://github.com/tazz4843/whisper-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-whisper-rs-sys = { path = "sys", version = "0.10.0" }
+whisper-rs-sys = { path = "sys", version = "0.10.1" }
 log = { version = "0.4", optional = true }
 tracing = { version = "0.1", optional = true }
 

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisper-rs-sys"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Rust bindings for whisper.cpp (FFI bindings)"
 license = "Unlicense"

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -184,6 +184,7 @@ fn main() {
         // debug builds are too slow to even remotely be usable,
         // so we build with optimizations even in debug mode
         config.define("CMAKE_BUILD_TYPE", "RelWithDebInfo");
+        config.cxxflag("-DWHISPER_DEBUG");
     }
 
     // Allow passing any WHISPER cmake flag


### PR DESCRIPTION
This is a fix for lang_detect function, return value changed a bit to return detected language id and array with probabilities of all languages.

Also I've enabled debug logs in whisper.cpp for debug builds.