### PR TITLE
fix: add missing search path for link opencl libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/Cargo.lock
 /.idea
 /.vscode
+/clblast
+*.7z
+*.bin

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -33,7 +33,10 @@ fn main() {
     #[cfg(feature = "opencl")]
     {
         if let Ok(clblast_dir) = env::var("CLBlast_DIR") {
-            println!("cargo::rustc-link-search={}", PathBuf::from(clblast_dir).join("..\\..").display());
+            println!(
+                "cargo::rustc-link-search={}",
+                PathBuf::from(clblast_dir).join("..\\..").display()
+            );
         }
         if let Ok(opencl_dir) = env::var("OPENCL_DIR") {
             println!("cargo::rustc-link-search={}", opencl_dir);

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -35,7 +35,7 @@ fn main() {
         if let Ok(clblast_dir) = env::var("CLBlast_DIR") {
             println!(
                 "cargo::rustc-link-search={}",
-                PathBuf::from(clblast_dir).join("..\\..").display()
+                PathBuf::from(clblast_dir).join("../..").display()
             );
         }
         if let Ok(opencl_dir) = env::var("OPENCL_DIR") {

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -32,7 +32,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=whisper.coreml");
     #[cfg(feature = "opencl")]
     {
-        if let Ok(clblast_dir) = env::var("CLBLast_DIR") {
+        if let Ok(clblast_dir) = env::var("CLBlast_DIR") {
             println!("cargo::rustc-link-search={}", PathBuf::from(clblast_dir).join("..\\..").display());
         }
         if let Ok(opencl_dir) = env::var("OPENCL_DIR") {

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -32,6 +32,12 @@ fn main() {
     println!("cargo:rustc-link-lib=static=whisper.coreml");
     #[cfg(feature = "opencl")]
     {
+        if let Ok(clblast_dir) = env::var("CLBLast_DIR") {
+            println!("cargo::rustc-link-search={}", PathBuf::from(clblast_dir).join("..\\..").display());
+        }
+        if let Ok(opencl_dir) = env::var("OPENCL_DIR") {
+            println!("cargo::rustc-link-search={}", opencl_dir);
+        }
         println!("cargo:rustc-link-lib=clblast");
         println!("cargo:rustc-link-lib=OpenCL");
     }


### PR DESCRIPTION
Test with the following in cmd.exe:
```console
winget install -e --id JernejSimoncic.Wget
winget install -e --id 7zip.7zip
C:\vcpkg\vcpkg.exe install opencl
wget "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin"
wget "https://github.com/CNugteren/CLBlast/releases/download/1.6.3/CLBlast-1.6.3-windows-x64.7z"
"C:\Program Files\7-Zip\7z" x CLBlast-1.6.3-windows-x64.7z
move CLBlast-1.6.3-windows-x64 clblast
set CLBlast_DIR=%cd%\clblast\lib\cmake\CLBlast
set OPENCL_DIR=C:\vcpkg\packages\opencl_x64-windows\lib
cargo run --example basic_use --features "opencl"
```

By the way very important note not sure where to place it:
Don't use opencl + openblas in programs that uses whisper-rs. it will crash. only opencl / openblas at a time.