### PR TITLE
fix: link openblas path correctly

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -37,7 +37,17 @@ fn main() {
     }
     #[cfg(feature = "openblas")]
     {
-        println!("cargo:rustc-link-lib=openblas");
+        if let Ok(openblas_path) = env::var("OPENBLAS_PATH") {
+            println!(
+                "cargo::rustc-link-search={}",
+                PathBuf::from(openblas_path).join("lib").display()
+            );
+        }
+        if cfg!(windows) {
+            println!("cargo:rustc-link-lib=libopenblas");
+        } else {
+            println!("cargo:rustc-link-lib=openblas");
+        }
     }
     #[cfg(feature = "cuda")]
     {


### PR DESCRIPTION
To test it on windows:

```console
wget "https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.26/OpenBLAS-0.3.26-x64.zip"
"C:\Program Files\7-Zip\7z" x OpenBLAS-0.3.26-x64.zip -oopenblas
set OPENBLAS_PATH=%cd%\openblas
cargo run --example basic_use --features "openblas"
```