### PR TITLE
Expose whisper.cpp version as a static string

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rustc-env=WHISPER_CPP_VERSION={}", env::var("DEP_WHISPER_WHISPER_CPP_VERSION").unwrap());
+}

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 use std::env;
 
 fn main() {
-    println!("cargo:rustc-env=WHISPER_CPP_VERSION={}", env::var("DEP_WHISPER_WHISPER_CPP_VERSION").unwrap());
+    println!(
+        "cargo:rustc-env=WHISPER_CPP_VERSION={}",
+        env::var("DEP_WHISPER_WHISPER_CPP_VERSION").unwrap()
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,3 +50,6 @@ pub type WhisperLogitsFilterCallback = whisper_rs_sys::whisper_logits_filter_cal
 pub type WhisperAbortCallback = whisper_rs_sys::ggml_abort_callback;
 pub type WhisperLogCallback = whisper_rs_sys::ggml_log_callback;
 pub type DtwAhead = whisper_rs_sys::whisper_ahead;
+
+/// The version of whisper.cpp that whisper-rs was linked with.
+pub static WHISPER_CPP_VERSION: &str = env!("WHISPER_CPP_VERSION");


### PR DESCRIPTION
Add a `WHISPER_CPP_VERSION` static that contains the version number of whisper.cpp that whisper-rs was built with. This can be useful for downstream applications for debugging and logging purposes.

This is implemented using [build script metadata](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) for whisper-rs-sys to expose the version number of whisper.cpp defined in `CMakeLists.txt` as metadata to crates that depend on it. Then whisper-rs accesses that build metadata and defines its own internal compile-time environment variable containing the same value, which is then assigned to a static variable.

It seemed better to expose this information through build metadata rather than defining a static in whisper-rs-sys directly, despite the extra indirection, so as to keep whisper-rs-sys as pure bindings.