### PR TITLE
fix: add search path for coreml on macOS

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -32,6 +32,7 @@ fn main() {
 
     #[cfg(feature = "coreml")]
     println!("cargo:rustc-link-lib=static=whisper.coreml");
+
     #[cfg(feature = "openblas")]
     {
         if let Ok(openblas_path) = env::var("OPENBLAS_PATH") {
@@ -233,6 +234,7 @@ fn main() {
     let destination = config.build();
 
     add_link_search_path(&out.join("lib")).unwrap();
+    add_link_search_path(&out.join("build/src")).unwrap();
 
     println!("cargo:rustc-link-search=native={}", destination.display());
     println!("cargo:rustc-link-lib=static=whisper");


### PR DESCRIPTION
The file `libwhisper.coreml.a` placed in `build/src`. 