### PR TITLE
fix: macos vulkan build script

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -191,6 +191,17 @@ fn main() {
             };
             let vulkan_lib_path = vulkan_path.join("Lib");
             println!("cargo:rustc-link-search={}", vulkan_lib_path.display());
+        } else if cfg!(target_os = "macos") {
+            println!("cargo:rerun-if-env-changed=VULKAN_SDK");
+            println!("cargo:rustc-link-lib=vulkan");
+            let vulkan_path = match env::var("VULKAN_SDK") {
+                Ok(path) => PathBuf::from(path),
+                Err(_) => panic!(
+                    "Please install Vulkan SDK and ensure that VULKAN_SDK env variable is set"
+                ),
+            };
+            let vulkan_lib_path = vulkan_path.join("lib");
+            println!("cargo:rustc-link-search={}", vulkan_lib_path.display());
         } else {
             println!("cargo:rustc-link-lib=vulkan");
         }


### PR DESCRIPTION
The PR fix the build on macos when targeting the vulkan backend. 
Targeting the master branch will result in ld failing to link against vulkan. See [GH action log](https://github.com/newfla/simple-whisper/actions/runs/10898814262/job/30242820759).
With the updated build.rs build process is fine [step _check whisper-rs vulkan build_](https://github.com/newfla/simple-whisper/actions/runs/10905411811/job/30264175328).