### PR TITLE
Make OpenMP optional instead of default dependency

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,9 +72,5 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
 
-      - name: Install OpenMP
-        run: brew install libomp
-        if: contains(matrix.os, 'macos')
-
       - name: Check build
         run: cargo build -F whisper-cpp-log,whisper-cpp-tracing --verbose --examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hound = "3.5.0"
 rand = "0.8.4"
 
 [features]
-default = ["openmp"]
+default = []
 
 raw-api = []
 coreml = ["whisper-rs-sys/coreml"]


### PR DESCRIPTION
Make OpenMP optional to improve compatibility with MacOS

## Background
Currently, OpenMP is specified as a default dependency in Cargo.toml. However, OpenMP is not installed by default on MacOS systems, which can cause unexpected build failures, especially in CI environments like GitHub Actions macOS runners.

## Changes
- Remove OpenMP from default features
- Make it available as an optional dependency, similar to whisper.cpp's approach

## Benefits
- Better out-of-the-box experience on MacOS
- No additional libomp installation required for basic builds
- Improved CI/CD workflow, especially on macOS runners
- More flexible dependency management for users

## Note
Users who want to use OpenMP can still enable it explicitly through features.