### PR TITLE
Added /utf-8 MSVC flag in sys crate for fixing UTF-8 errors

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -246,6 +246,10 @@ fn main() {
         config.define("GGML_OPENMP", "OFF");
     }
 
+    if cfg!(windows) {
+        config.cxxflag("/utf-8");
+    }
+
     let destination = config.build();
 
     add_link_search_path(&out.join("build")).unwrap();


### PR DESCRIPTION
Specifically, in whisper.cpp, at line 4892, 「 」『 』these 4 characters cause error C3688 which doesn't let the crate get compiled under Windows. This small fix adds the required flag that fixes this issue. I am quite surprised that no one reported this (unless I am blind because I did not see it in any issues or pull requests. 