### PR TITLE
Update whisper.cpp to v1.7.4; rename suppress_nst

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sys/whisper.cpp"]
 	path = sys/whisper.cpp
-	url = https://github.com/ggerganov/whisper.cpp
+	url = https://github.com/thewh1teagle/whisper.cpp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sys/whisper.cpp"]
 	path = sys/whisper.cpp
-	url = https://github.com/thewh1teagle/whisper.cpp
+	url = https://github.com/ggerganov/whisper.cpp

--- a/src/standalone.rs
+++ b/src/standalone.rs
@@ -105,8 +105,6 @@ pub struct SystemInfo {
     pub avx2: bool,
     pub fma: bool,
     pub f16c: bool,
-    pub blas: bool,
-    pub cuda: bool,
 }
 
 impl Default for SystemInfo {
@@ -117,8 +115,6 @@ impl Default for SystemInfo {
                 avx2: whisper_rs_sys::ggml_cpu_has_avx2() != 0,
                 fma: whisper_rs_sys::ggml_cpu_has_fma() != 0,
                 f16c: whisper_rs_sys::ggml_cpu_has_f16c() != 0,
-                blas: whisper_rs_sys::ggml_cpu_has_blas() != 0,
-                cuda: whisper_rs_sys::ggml_cpu_has_cuda() != 0,
             }
         }
     }

--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -299,6 +299,15 @@ impl<'a, 'b> FullParams<'a, 'b> {
         self.fp.suppress_blank = suppress_blank;
     }
 
+    /// Set suppress_non_speech_tokens.
+    /// See <https://github.com/openai/whisper/blob/7858aa9c08d98f75575035ecd6481f462d66ca27/whisper/tokenizer.py#L224-L253>
+    /// for more information.
+    ///
+    /// Defaults to false.
+    pub fn set_suppress_nst(&mut self, suppress_nst: bool) {
+        self.fp.suppress_nst = suppress_nst;
+    }
+
     /// Set initial decoding temperature.
     /// See <https://ai.stackexchange.com/a/32478> for more information.
     ///

--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -299,15 +299,6 @@ impl<'a, 'b> FullParams<'a, 'b> {
         self.fp.suppress_blank = suppress_blank;
     }
 
-    /// Set suppress_non_speech_tokens.
-    /// See <https://github.com/openai/whisper/blob/7858aa9c08d98f75575035ecd6481f462d66ca27/whisper/tokenizer.py#L224-L253>
-    /// for more information.
-    ///
-    /// Defaults to false.
-    pub fn set_suppress_non_speech_tokens(&mut self, suppress_non_speech_tokens: bool) {
-        self.fp.suppress_non_speech_tokens = suppress_non_speech_tokens;
-    }
-
     /// Set initial decoding temperature.
     /// See <https://ai.stackexchange.com/a/32478> for more information.
     ///

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -261,7 +261,6 @@ fn main() {
     if cfg!(feature = "vulkan") {
         println!("cargo:rustc-link-lib=static=ggml-vulkan");
     }
-    
 
     if cfg!(feature = "metal") {
         println!("cargo:rustc-link-lib=static=ggml-metal");

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -253,6 +253,19 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", destination.display());
     println!("cargo:rustc-link-lib=static=whisper");
     println!("cargo:rustc-link-lib=static=ggml");
+    println!("cargo:rustc-link-lib=static=ggml-base");
+    println!("cargo:rustc-link-lib=static=ggml-cpu");
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=static=ggml-blas");
+    }
+    if cfg!(feature = "vulkan") {
+        println!("cargo:rustc-link-lib=static=ggml-vulkan");
+    }
+    
+
+    if cfg!(feature = "metal") {
+        println!("cargo:rustc-link-lib=static=ggml-metal");
+    }
 
     println!(
         "cargo:WHISPER_CPP_VERSION={}",


### PR DESCRIPTION
This PR is based on the changes by @thewh1teagle and the PR #193 

I forked @thewh1teagle 's fork, applied the changes, changed whisper.cpp back to the original repository and pushed the submodule to the latest whisper.cpp version. Also, I renamed the `set_suppress_non_speech_tokens`-function to `set_suppress_nst`.

I tested it in a tauri macOS and iOS app, it works very good.