### PR TITLE
link cuda when cuda feature is on

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -265,6 +265,10 @@ fn main() {
     if cfg!(feature = "metal") {
         println!("cargo:rustc-link-lib=static=ggml-metal");
     }
+    
+    if cfg!(feature = "cuda") {
+        println!("cargo:rustc-link-lib=static=ggml-cuda");
+    }
 
     println!(
         "cargo:WHISPER_CPP_VERSION={}",

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -265,7 +265,7 @@ fn main() {
     if cfg!(feature = "metal") {
         println!("cargo:rustc-link-lib=static=ggml-metal");
     }
-    
+
     if cfg!(feature = "cuda") {
         println!("cargo:rustc-link-lib=static=ggml-cuda");
     }


### PR DESCRIPTION
This is a minor bugfix. When I tried to build whisper-rs with cuda, I noticed that the linker is never told explicitly to link the library `ggml-cuda.lib`. This pr should fix the problem.