### PR TITLE
Use UTF-8 to build whisper.cpp on Windows

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -164,6 +164,10 @@ fn main() {
         .very_verbose(true)
         .pic(true);
 
+    if cfg!(target_os = "windows") {
+        config.cxxflag("/utf-8");
+    }
+
     if cfg!(feature = "coreml") {
         config.define("WHISPER_COREML", "ON");
         config.define("WHISPER_COREML_ALLOW_FALLBACK", "1");


### PR DESCRIPTION
In some non-English language environments, building sys crate on Windows fails.

For example, if the Windows system language is set to Japanese, the default system charset is CP932.