### PR TITLE
doc: fixed feature flag names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ All disabled by default unless otherwise specified.
 * `openblas`: enable OpenBLAS support.
 * `metal`: enable Metal support. Implicitly enables hidden GPU flag at runtime.
 * `vulkan`: enable Vulkan support. Implicitly enables hidden GPU flag at runtime.
-* `whisper-cpp-log`: allows hooking into whisper.cpp's log output and sending it to the `log` backend. Requires calling
-* `whisper-cpp-tracing`: allows hooking into whisper.cpp's log output and sending it to the `tracing` backend.
+* `log_backend`: allows hooking into whisper.cpp's log output and sending it to the `log` backend. Requires calling
+* `tracing_backend`: allows hooking into whisper.cpp's log output and sending it to the `tracing` backend.
 
 ## Building
 


### PR DESCRIPTION
The feature flags seem to have changed from `whisper-cpp-tracing` and `whisper-cpp-log` to `tracing_backend` and `log_backend` at some point.

This PR is just a simple doc fix to update references to these flags in the `README.md`.