### PR TITLE
fix: static link `ggml-blas` if openblas feature is enabled

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -280,6 +280,10 @@ fn main() {
         println!("cargo:rustc-link-lib=static=ggml-cuda");
     }
 
+    if cfg!(feature = "openblas") {
+        println!("cargo:rustc-link-lib=static=ggml-blas");
+    }
+
     println!(
         "cargo:WHISPER_CPP_VERSION={}",
         get_whisper_cpp_version(&whisper_root)


### PR DESCRIPTION
... I'm getting `undefined symbol: ggml_backend_blas_reg` otherwise.

```
  = note: some arguments are omitted. use `--verbose` to show all linker arguments                                                                             
  = note: mold: error: undefined symbol: ggml_backend_blas_reg                                                                                                 
          >>> referenced by ggml-backend-reg.cpp                                                                                                               
          >>>               /home/kaspar/src.old/own/whisper-http-service/target/debug/deps/libwhisper_rs_sys-4616210e579be9da.rlib(ggml-backend-reg.cpp.o):(gg
ml_backend_registry::ggml_backend_registry())                                                                                                                  
          clang: error: linker command failed with exit code 1 (use -v to see invocation)                                                                      
```