### PR TITLE
Fix/progress callback crash

### DIFF
--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -38,7 +38,7 @@ pub struct FullParams<'a, 'b> {
     phantom_lang: PhantomData<&'a str>,
     phantom_tokens: PhantomData<&'b [c_int]>,
     grammar: Option<Vec<whisper_rs_sys::whisper_grammar_element>>,
-    progess_callback_safe: Option<Arc<Box<dyn FnMut(i32)>>>,
+    progress_callback_safe: Option<Arc<Box<dyn FnMut(i32)>>>,
     abort_callback_safe: Option<Arc<Box<dyn FnMut() -> bool>>>,
     segment_calllback_safe: Option<Arc<SegmentCallbackFn>>,
 }
@@ -75,7 +75,7 @@ impl<'a, 'b> FullParams<'a, 'b> {
             phantom_lang: PhantomData,
             phantom_tokens: PhantomData,
             grammar: None,
-            progess_callback_safe: None,
+            progress_callback_safe: None,
             abort_callback_safe: None,
             segment_calllback_safe: None,
         }
@@ -581,12 +581,12 @@ impl<'a, 'b> FullParams<'a, 'b> {
                 let boxed_closure = Box::new(boxed_closure);
                 let raw_ptr = Box::into_raw(boxed_closure);
                 self.fp.progress_callback_user_data = raw_ptr as *mut c_void;
-                self.progess_callback_safe = None;
+                self.progress_callback_safe = None;
             }
             None => {
                 self.fp.progress_callback = None;
                 self.fp.progress_callback_user_data = std::ptr::null_mut::<c_void>();
-                self.progess_callback_safe = None;
+                self.progress_callback_safe = None;
             }
         }
     }

--- a/src/whisper_params.rs
+++ b/src/whisper_params.rs
@@ -575,11 +575,13 @@ impl<'a, 'b> FullParams<'a, 'b> {
         }
 
         match closure.into() {
-            Some(mut closure) => {
-                self.fp.progress_callback = Some(trampoline::<F>);
-                self.fp.progress_callback_user_data = &mut closure as *mut F as *mut c_void;
-                // store the closure internally to make sure that the pointer above remains valid
-                self.progess_callback_safe = Some(Arc::new(Box::new(closure)));
+            Some(closure) => {
+                self.fp.progress_callback = Some(trampoline::<Box<dyn FnMut(i32)>>);
+                let boxed_closure = Box::new(closure) as Box<dyn FnMut(i32)>;
+                let boxed_closure = Box::new(boxed_closure);
+                let raw_ptr = Box::into_raw(boxed_closure);
+                self.fp.progress_callback_user_data = raw_ptr as *mut c_void;
+                self.progess_callback_safe = None;
             }
             None => {
                 self.fp.progress_callback = None;


### PR DESCRIPTION
This PR addresses the issue described in https://github.com/tazz4843/whisper-rs/issues/134.

It fixes the issue here "on my machine", and I was waiting for someone else in the issue thread to confirm that it works elsewhere without introducing new bugs. My comment didn't get much attention however, so here we are. 

The fix essentially is in this commit: https://github.com/rasteiner/whisper-rs/commit/807bc242e967b5840227797c7a249a293f546a67

It essentially reproduces the same technique which is used elsewhere in the same code file: boxing the callback twice and then calling `into_raw`. See `set_segment_callback_safe`, `set_segment_callback_safe_lossy` and `set_abort_callback_safe`. 
`set_progress_callback_safe` was the only place where `&mut closure as *mut F as *mut c_void` was used. 

The other commits fix a spelling error of "progess" -> "progress" and merge unrelated new code from master. 