### PR TITLE
fix: Correct broken hipblas build

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -178,7 +178,7 @@ fn main() {
     }
 
     if cfg!(feature = "hipblas") {
-        config.define("GGML_HIPBLAS", "ON");
+        config.define("GGML_HIP", "ON");
         config.define("CMAKE_C_COMPILER", "hipcc");
         config.define("CMAKE_CXX_COMPILER", "hipcc");
         println!("cargo:rerun-if-env-changed=AMDGPU_TARGETS");
@@ -270,6 +270,10 @@ fn main() {
     }
     if cfg!(feature = "vulkan") {
         println!("cargo:rustc-link-lib=static=ggml-vulkan");
+    }
+
+    if cfg!(feature = "hipblas") {
+        println!("cargo:rustc-link-lib=static=ggml-hip");
     }
 
     if cfg!(feature = "metal") {


### PR DESCRIPTION
GGML_HIPBLAS was renamed to GGML_HIP as part of the library refactoring work in [llama.cpp](https://github.com/ggml-org/llama.cpp/pull/10256) and then subsequently ported to [whisper.cpp](https://github.com/ggml-org/whisper.cpp/pull/2573/commits/ce58be7e79e96007759ad44a31caf40730940452).

This fix now allows this library to be compiled with rocm v6.