### PR TITLE
Fix CUDA linking error by ensuring -fPIC for position-independent code

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -175,8 +175,6 @@ fn main() {
 
     if cfg!(feature = "cuda") {
         config.define("GGML_CUDA", "ON");
-        config.define("NVCC_APPEND_FLAGS", "-fPIC");
-        config.cxxflag("-fPIC");
         config.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
         config.define("CMAKE_CUDA_FLAGS", "-Xcompiler=-fPIC");
     }

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -177,6 +177,8 @@ fn main() {
         config.define("GGML_CUDA", "ON");
         config.define("NVCC_APPEND_FLAGS", "-fPIC");
         config.cxxflag("-fPIC");
+        config.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
+        config.define("CMAKE_CUDA_FLAGS", "-Xcompiler=-fPIC");
     }
 
     if cfg!(feature = "hipblas") {

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -175,6 +175,8 @@ fn main() {
 
     if cfg!(feature = "cuda") {
         config.define("GGML_CUDA", "ON");
+        config.define("NVCC_APPEND_FLAGS", "-fPIC");
+        config.cxxflag("-fPIC");
     }
 
     if cfg!(feature = "hipblas") {


### PR DESCRIPTION
Resolves a linker error when building with feature `cuda`, such that nvcc compiled & linked objects get compiled with position-independent code (`-fPIC`). I noticed that this was not getting done when building `whisper-rs` into https://github.com/mz2/pipescribe: when enabling the `cuda` feature, `cargo`, the following linker error would occur:

```
...
"-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/mz2/Developer/pipescribe/gui/rust/target/debug/deps/librust_lib_pipescribe.so" "-Wl,--gc-sections" "-shared" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: some arguments are omitted. use --verbose to show all linker arguments
  = note: /usr/bin/ld: /home/mz2/Developer/pipescribe/gui/rust/target/debug/deps/libwhisper_rs_sys-193aab817605690a.rlib(fattn.cu.o): warning: relocation against stderr@@GLIBC_2.2.5' in read-only section .text'
          /usr/bin/ld: /home/mz2/Developer/pipescribe/gui/rust/target/debug/deps/libwhisper_rs_sys-193aab817605690a.rlib(mmq-instance-iq1_s.cu.o): relocation R_X86_64_PC32 against symbol stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
          /usr/bin/ld: final link failed: bad value
          collect2: error: ld returned 1 exit status
```

I have confirmed this to be fixed with the changes in this PR.