### PR TITLE
Fixes building on arm64 / Linux

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -256,7 +256,7 @@ fn main() {
         config.define("GGML_OPENMP", "OFF");
     }
 
-    if target.contains("aarch64") {
+    if target.contains("aarch64") && target.contains("linux") {
         config.define("GGML_NATIVE", "OFF");
         config.define("GGML_CPU_ARM_ARCH", "native");
     }

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -256,6 +256,11 @@ fn main() {
         config.define("GGML_OPENMP", "OFF");
     }
 
+    if target.contains("aarch64") {
+        config.define("GGML_NATIVE", "OFF");
+        config.define("GGML_CPU_ARM_ARCH", "native");
+    }
+
     let destination = config.build();
 
     add_link_search_path(&out.join("build")).unwrap();


### PR DESCRIPTION
As per https://github.com/ggml-org/whisper.cpp/issues/2719#issuecomment-2603066656 building on Linux & ARM64 (M1 in my case) is failing with something to the effect of:

```
  cc1: error: unknown value 'native+nodotprod+noi8mm+nosve' for '-mcpu'
  cc1: note: valid arguments are: cortex-a34 cortex-a35 cortex-a53 cortex-a57 cortex-a72 cortex-a73 thunderx thunderxt88p1 thunderxt88 octeontx octeontx81 octeontx83 thunderxt81 thunderxt83 ampere1 ampere1a emag xgene1 falkor qdf24xx exynos-m1 phecda thunderx2t99p1 vulcan thunderx2t99 cortex-a55 cortex-a75 cortex-a76 cortex-a76ae cortex-a77 cortex-a78 cortex-a78ae cortex-a78c cortex-a65 cortex-a65ae cortex-x1 cortex-x1c neoverse-n1 ares neoverse-e1 octeontx2 octeontx2t98 octeontx2t96 octeontx2t93 octeontx2f95 octeontx2f95n octeontx2f95mm a64fx tsv110 thunderx3t110 neoverse-v1 zeus neoverse-512tvb saphira cortex-a57.cortex-a53 cortex-a72.cortex-a53 cortex-a73.cortex-a35 cortex-a73.cortex-a53 cortex-a75.cortex-a55 cortex-a76.cortex-a55 cortex-r82 cortex-a510 cortex-a710 cortex-a715 cortex-x2 cortex-x3 neoverse-n2 cobalt-100 neoverse-v2 grace demeter generic
  gmake[2]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/build.make:93: ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.cpp.o] Error 1
  gmake[2]: *** Waiting for unfinished jobs....
  gmake[2]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/build.make:79: ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.c.o] Error 1
  gmake[1]: *** [CMakeFiles/Makefile2:208: ggml/src/CMakeFiles/ggml-cpu.dir/all] Error 2
  gmake: *** [Makefile:139: all] Error 2
```