### PR TITLE
added best effort method to avoid failed UTF-8 decoding

### DIFF
--- a/src/whisper_state.rs
+++ b/src/whisper_state.rs
@@ -385,6 +385,12 @@ impl WhisperState {
         Ok(self.full_get_segment_raw(segment)?.to_str()?.to_string())
     }
 
+    /// This avoids panics and gives you best-effort UTF-8 (replacing invalid bytes with �).
+    pub fn full_get_segment_text_best_effort(&self, segment: c_int) -> Result<String, WhisperError> {
+        let raw = self.full_get_segment_raw(segment)?;
+        Ok(String::from_utf8_lossy(raw).into_owned())
+    }
+
     /// Get the text of the specified segment.
     /// This function differs from [WhisperState::full_get_segment_text]
     /// in that it ignores invalid UTF-8 in whisper strings,


### PR DESCRIPTION
I noticed that it throws the entire segment out if it fails to decode it as a UTF-8 &str. I have added a method that would allow such behavior.

Here is the error:
![image](https://github.com/user-attachments/assets/0c5360d0-6b23-4241-a906-04fd9d0ecf7f)

Here is the code that resulted in this:
![image](https://github.com/user-attachments/assets/ca249d81-f6da-4547-aa9e-72431e91a5be)
