### PR TITLE
feat: add intel sycl support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ openblas = ["whisper-rs-sys/openblas"]
 metal = ["whisper-rs-sys/metal", "_gpu"]
 vulkan = ["whisper-rs-sys/vulkan", "_gpu"]
 openmp = ["whisper-rs-sys/openmp"]
+intel-sycl = ["whisper-rs-sys/intel-sycl", "_gpu"]
 _gpu = []
 test-with-tiny-model = []
 

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -35,6 +35,7 @@ metal = []
 vulkan = []
 force-debug = []
 openmp = []
+intel-sycl = []
 
 [build-dependencies]
 cmake = "0.1"


### PR DESCRIPTION
Adding Intel Sycl with the feature flag `intel-sycl` to it. Static linking the intel sycl isn't possible, that's the reason why it's dynamic linked.

Compiling the crate with static linking is working, but then I get that weird linker error on runtime level. I was only able to solve that problem by linking it dynamically.
The logs when I tried it staticly:
```
   Compiling whisper-rs-sys v0.13.0 (/home/kerkmann/git/whisper-rs-recu/sys)
   Compiling whisper-rs v0.14.3 (/home/kerkmann/git/whisper-rs-recu)
   Compiling opentalk-transcription v0.1.0 (/home/kerkmann/git/transcription)
error: linking with `clang` failed: exit status: 1
  |
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld.lld: error: undefined symbol: _intel_fast_memcpy
          >>> referenced by ggml-cpu.cpp
          >>>               ggml-cpu.cpp.o:(ggml_backend_cpu_get_extra_buffers_type()::$_0::operator()() const) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.cpp
          >>>               ggml-cpu.cpp.o:(ggml_backend_cpu_get_extra_buffers_type()::$_0::operator()() const) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.cpp
          >>>               ggml-cpu.cpp.o:(ggml_backend_cpu_get_features(ggml_backend_reg*)::$_0::operator()() const) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 1131 more times

          ld.lld: error: undefined symbol: _intel_fast_memset
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_set_f32) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_set_f32) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_set_f32) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 248 more times

          ld.lld: error: undefined symbol: __cpu_core_type
          >>> referenced by ggml-cpu-aarch64.cpp
          >>>               ggml-cpu-aarch64.cpp.o:(ggml::cpu::aarch64::tensor_traits<block_q4_0, 4l, 4l>::forward_mul_mat(ggml_compute_params*, ggml_tensor*)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu-aarch64.cpp
          >>>               ggml-cpu-aarch64.cpp.o:(ggml::cpu::aarch64::tensor_traits<block_iq4_nl, 4l, 4l>::forward_mul_mat(ggml_compute_params*, ggml_tensor*)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 5 more times

          ld.lld: error: undefined symbol: __detect_cpu_core_type
          >>> referenced by ggml-cpu-aarch64.cpp
          >>>               ggml-cpu-aarch64.cpp.o:(ggml::cpu::aarch64::tensor_traits<block_q4_0, 4l, 4l>::forward_mul_mat(ggml_compute_params*, ggml_tensor*)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu-aarch64.cpp
          >>>               ggml-cpu-aarch64.cpp.o:(ggml::cpu::aarch64::tensor_traits<block_iq4_nl, 4l, 4l>::forward_mul_mat(ggml_compute_params*, ggml_tensor*)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 5 more times

          ld.lld: error: undefined symbol: __svml_tanhf8_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_cpu_init) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 1 more times

          ld.lld: error: undefined symbol: __svml_expf8_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_cpu_init) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 17 more times

          ld.lld: error: undefined symbol: __svml_logf4
          >>> referenced by ggml.c
          >>>               ggml.c.o:(ggml_rope_yarn_corr_dims) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_logf8_mask_e9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_logf8_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_sinf8_mask_e9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_sinf8_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_cosf8_mask_e9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_cosf8_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_expf8_mask_e9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 15 more times

          ld.lld: error: undefined symbol: __svml_tanhf8_mask_e9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_expm1f8_mask_e9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 1 more times

          ld.lld: error: undefined symbol: __libm_sse2_sincosf
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_graph_compute_thread) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 81 more times

          ld.lld: error: undefined symbol: __svml_cosf4_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_compute_forward_rope_f16) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_compute_forward_rope_f32) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: __svml_sinf4_l9
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_compute_forward_rope_f16) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by ggml-cpu.c
          >>>               ggml-cpu.c.o:(ggml_compute_forward_rope_f32) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib

          ld.lld: error: undefined symbol: sycl::_V1::detail::tls_code_loc_t::tls_code_loc_t(sycl::_V1::detail::code_location const&)
          >>> referenced by tsembd.cpp
          >>>               tsembd.cpp.o:(ggml_sycl_op_timestep_embedding(ggml_backend_sycl_context&, ggml_tensor const*, ggml_tensor const*, ggml_tensor*)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by tsembd.cpp
          >>>               tsembd.cpp.o:(ggml_sycl_op_timestep_embedding(ggml_backend_sycl_context&, ggml_tensor const*, ggml_tensor const*, ggml_tensor*)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced by softmax.cpp
          >>>               softmax.cpp.o:(ggml_sycl_op_soft_max(ggml_backend_sycl_context&, ggml_tensor const*, ggml_tensor const*, ggml_tensor*, float const*, float const*, float*, sycl::_V1::queue* const&)) in archive /home/kerkmann/git/transcription/target/release/deps/libwhisper_rs_sys-7d79bb62e177851d.rlib
          >>> referenced 356 more times

          ld.lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `opentalk-transcription` (bin "opentalk-transcription") due to 1 previous error
```