### PR TITLE
Fix wrong type on aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/tazz4843/whisper-rs"
 whisper-rs-sys = { path = "sys", version = "0.13" }
 log = { version = "0.4", optional = true }
 tracing = { version = "0.1", optional = true }
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 hound = "3.5.0"
@@ -31,7 +32,7 @@ cuda = ["whisper-rs-sys/cuda", "_gpu"]
 hipblas = ["whisper-rs-sys/hipblas", "_gpu"]
 openblas = ["whisper-rs-sys/openblas"]
 metal = ["whisper-rs-sys/metal", "_gpu"]
-vulkan = ["whisper-rs-sys/vulkan", "_gpu"]
+vulkan = ["whisper-rs-sys/vulkan", "_gpu", "dep:libc"]
 openmp = ["whisper-rs-sys/openmp"]
 _gpu = []
 test-with-tiny-model = []

--- a/src/vulkan.rs
+++ b/src/vulkan.rs
@@ -29,7 +29,7 @@ pub fn list_devices() -> Vec<VkDeviceInfo> {
         (0..n)
             .map(|id| {
                 // 256 bytes is plenty (spec says 128 is enough)
-                let mut tmp = [0i8; 256];
+                let mut tmp: [libc::c_char; 256] = [0; 256];
                 ggml_backend_vk_get_device_description(id as c_int, tmp.as_mut_ptr(), tmp.len());
                 let mut free = 0usize;
                 let mut total = 0usize;


### PR DESCRIPTION
Trying to build in a Raspberry Pi I get the following error:

```rust
error[E0308]: mismatched types
    --> /root/whisper-rs/src/vulkan.rs:33:69
     |
33   |                 ggml_backend_vk_get_device_description(id as c_int, tmp.as_mut_ptr(), tmp.len());
     |                 --------------------------------------              ^^^^^^^^^^^^^^^^ expected `*mut u8`, found `*mut i8`
     |                 |
     |                 arguments to this function are incorrect
     |
     = note: expected raw pointer `*mut u8`
                found raw pointer `*mut i8`
note: function defined here
    --> /root/whisper-tst/target/debug/build/whisper-rs-sys-fdc42e82b8d8a876/out/bindings.rs:5345:12
     |
5345 |     pub fn ggml_backend_vk_get_device_description(
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
  --> /root/whisper-rs/src/vulkan.rs:39:42
   |
39 |                     name: CStr::from_ptr(tmp.as_ptr()).to_string_lossy().into_owned(),
   |                           -------------- ^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
   |                           |
   |                           arguments to this function are incorrect
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*const i8`
```

See: https://github.com/remacs/remacs/issues/1393